### PR TITLE
Change to use variant's root instead of uri

### DIFF
--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -465,13 +465,15 @@ class Packages(AbstractDockWidget):
 
         def on_openfile():
             package = model_.data(index, "package")
-            fname = os.path.join(package.root, "package.py")
+            pkg_uri = os.path.dirname(package.uri)
+            fname = os.path.join(pkg_uri, "package.py")
             util.open_file_location(fname)
             self.message.emit("Opened %s" % fname)
 
         def on_copyfile():
             package = model_.data(index, "package")
-            fname = os.path.join(package.root, "package.py")
+            pkg_uri = os.path.dirname(package.uri)
+            fname = os.path.join(pkg_uri, "package.py")
             clipboard = QtWidgets.QApplication.instance().clipboard()
             clipboard.setText(fname)
             self.message.emit("Copied %s" % fname)

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -187,7 +187,7 @@ class ApplicationModel(AbstractTableModel):
         self.items[:] = []
 
         for app in applications:
-            root = os.path.dirname(app.uri)
+            root = app.root
 
             data = allzparkconfig.metadata_from_package(app)
             tools = getattr(app, "tools", None) or [app.name]
@@ -362,7 +362,7 @@ class PackagesModel(AbstractTableModel):
         paths = self._ctrl._package_paths()
 
         for pkg in packages:
-            root = os.path.dirname(pkg.uri)
+            root = pkg.root
             data = allzparkconfig.metadata_from_package(pkg)
             state = (
                 "(dev)" if is_local(pkg) else


### PR DESCRIPTION
### Problem

If the application package has variants, using `uri` attribute to format path like `{root}/sub-dir` is incorrect.

For example (the `default` is the variant) :
```
> pkg.uri
/Users/davidlatwe/rez/packages/install/mockmaya/2018/package.py[0]
> pkg.root
/Users/davidlatwe/rez/packages/install/mockmaya/2018/default
```

### Change

Use attribute `root` when the package object is a variant. ☺️ 
