### PR TITLE
Drop normpath on rez.config.nonlocal_packages_path

### DIFF
--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -950,7 +950,7 @@ class Controller(QtCore.QObject):
 
         # Optional development packages
         if not self._state.retrieve("useDevelopmentPackages"):
-            paths = util.normpaths(*rez.config.nonlocal_packages_path)
+            paths = rez.config.nonlocal_packages_path[:]
 
         # Optional package localisation
         if localz and not self._state.retrieve("useLocalizedPackages", True):


### PR DESCRIPTION
This resolves the same issue memtioned in https://github.com/mottosso/allzpark/pull/102#issuecomment-675002154, which is not to assume packages are all file-system based and not to do any additional path process.