### PR TITLE
Fix JsonView sorting and serializing

### DIFF
--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -708,7 +708,11 @@ class JsonView(QtWidgets.QTreeView):
             else:
                 data = model_.json()
 
-            text = str(data)
+            text = json.dumps(data,
+                              indent=4,
+                              sort_keys=True,
+                              ensure_ascii=False)
+
             app = QtWidgets.QApplication.instance()
             app.clipboard().setText(text)
 

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -541,6 +541,9 @@ class CommandsModel(AbstractTableModel):
 
 
 class JsonModel(qjsonmodel.QJsonModel):
+
+    JsonRole = QtCore.Qt.UserRole + 1
+
     def setData(self, index, value, role):
         # Support copy/paste, but prevent edits
         return False
@@ -562,7 +565,12 @@ class JsonModel(qjsonmodel.QJsonModel):
             if index.column() == 1:
                 return item.value
 
+        if role == self.JsonRole:
+            return self.json(item)
+
         return super(JsonModel, self).data(index, role)
+
+    reset = qjsonmodel.QJsonModel.clear
 
 
 class EnvironmentModel(JsonModel):

--- a/allzpark/vendor/qjsonmodel.py
+++ b/allzpark/vendor/qjsonmodel.py
@@ -113,7 +113,7 @@ class QJsonTreeItem(object):
         elif isinstance(value, list):
             for index, value in enumerate(value):
                 child = self.load(value, rootItem)
-                child.key = str(index)
+                child.key = index
                 child.type = type(value)
                 rootItem.appendChild(child)
 
@@ -125,15 +125,13 @@ class QJsonTreeItem(object):
 
 
 class QJsonModel(QtCore.QAbstractItemModel):
-    JsonRole = QtCore.Qt.UserRole + 1
-
     def __init__(self, parent=None):
         super(QJsonModel, self).__init__(parent)
 
         self._rootItem = QJsonTreeItem()
         self._headers = ("key", "value")
 
-    def reset(self):
+    def clear(self):
         self.load({})
 
     def load(self, document):
@@ -189,9 +187,6 @@ class QJsonModel(QtCore.QAbstractItemModel):
         elif role == QtCore.Qt.EditRole:
             if index.column() == 1:
                 return item.value
-
-        if role == QJsonModel.JsonRole:
-            return self.json(item)
 
     def setData(self, index, value, role):
         if role == QtCore.Qt.EditRole:


### PR DESCRIPTION
* This PR fix #91, and update vendored `qjsonmodel.py` from the source project which can resolve the issue. Noted that I also move previous local changes out of vendored module.

* The *full copy* action in `JsonView` only use `str` conversion, so I change to use `json.dumps` to make it return valid json syntax string.
