### PR TITLE
Fix dock hidden

### DIFF
--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -458,7 +458,7 @@ class Window(QtWidgets.QMainWindow):
     def on_dock_toggled(self, dock, visible):
         """Make toggled dock the active dock"""
 
-        if not visible or dock == self._docks["profiles"]:
+        if not visible:
             return
 
         # Handle the easy cases first
@@ -467,11 +467,19 @@ class Window(QtWidgets.QMainWindow):
         allow_multiple = bool(self._ctrl.state.retrieve("allowMultipleDocks"))
 
         if ctrl_held or not allow_multiple:
+            ignore_allow_multiple = [
+                # docks that are not restricted by this rule
+                "profiles",
+            ]
+
             for name, d in self._docks.items():
-                if name == "profiles":
+                if name in ignore_allow_multiple:
                     continue
                 d.setVisible(d == dock)
-            return
+
+            if len([d for d in self._docks.values() if d.isVisible()]) <= 1:
+                # Only one or no visible dock
+                return
 
         # Otherwise we'll want to make the newly visible dock the active tab.
 

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -482,7 +482,7 @@ class Window(QtWidgets.QMainWindow):
         # TabBar's are dynamically created as the user
         # moves docks around, and not all of them are
         # visible or in use at all times. (Poor garbage collection)
-        bars = self.findChildren(QtWidgets.QTabBar)
+        bars = self.findChildren(QtWidgets.QTabBar, "")
 
         # The children of a QTabBar isn't the dock directly, but rather
         # the buttons in the tab, which are of type QToolButton.


### PR DESCRIPTION
### Problem 1

![before](https://user-images.githubusercontent.com/3357009/96864045-665fb700-149a-11eb-804c-461d4cbb25df.gif)

As you can see in the above GIF, the "Context" is not pop-up when I activate it.

It seems like it's not looking into the correct `QTabBar` and somehow the wrong `QTabBar` also has same named tab (might be the `QTabBar` inside the "Environment" tab which also has a tab named "Context").

When I print out the `objectName` of those `bars` :

https://github.com/mottosso/allzpark/blob/4bb9851578a7fd8a4a2760bce0bcc7ae78ea55a1/allzpark/view.py#L485

This is what I got :

```python
['qt_tabwidget_tabbar', 'qt_tabwidget_tabbar', 'qt_tabwidget_tabbar', 'qt_tabwidget_tabbar', '', '', '', '']
```

And looks like those unnamed (`''`) tab bars are the right one to look up to, not sure what `"qt_tabwidget_tabbar"` are .. :S

Anyway, commit ba4351f resolved this problem.

### Problem 2

The "Profiles" page can ignore the "Allow Multiple Docks" setting, which makes the header may have more than 1 active dock. And in previous implementation, the logic didn't try to bring "Profiles" page to up front, it just being ignored.

Commit 526f762 resolved this problem.

### Fixed Result

![after](https://user-images.githubusercontent.com/3357009/96865379-77a9c300-149c-11eb-8a14-280528c3243a.gif)
