### PR TITLE
Allow setting parent environment explicitly

### DIFF
--- a/allzpark/_rezapi.py
+++ b/allzpark/_rezapi.py
@@ -7,6 +7,7 @@ from rez.package_filter import Rule, PackageFilterList
 from rez.package_repository import package_repository_manager
 from rez.packages_ import Package
 from rez.utils.formatting import PackageRequest
+from rez.system import system
 from rez.config import config
 from rez.util import which
 from rez import __version__ as version
@@ -62,6 +63,7 @@ __all__ = [
     "project",
     "copy_package",
     "package_repository_manager",
+    "system",
 
     # Classes
     "Package",

--- a/allzpark/allzparkconfig.py
+++ b/allzpark/allzparkconfig.py
@@ -126,3 +126,20 @@ def themes():
 
     """
     return []
+
+
+def application_parent_environment():
+    """Application's launching environment
+
+    You may want to set this so the application won't be inheriting current
+    environment which is used to launch Allzpark. E.g. when Allzaprk is
+    launched from a Rez resolved context.
+
+    But if using bleeding-rez, and `config.inherit_parent_environment` is
+    set to False, config will be respected and this will be ignored.
+
+    Returns:
+        dict
+
+    """
+    return None

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1,6 +1,7 @@
 """Orchestrates view.py and model.py"""
 
 import os
+import sys
 import time
 import json
 import errno
@@ -1172,10 +1173,10 @@ class Controller(QtCore.QObject):
         app_request = self._state["appRequest"]
 
         command = (
-            'python -c "'
+            '%s -c "'
             'import os,sys,json;'
             'sys.stdout.write(json.dumps(os.environ.copy(),ensure_ascii=0))"'
-        )
+        ) % sys.executable
 
         def load(message):
             try:

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1171,14 +1171,20 @@ class Controller(QtCore.QObject):
     def test_environment(self):
         app_request = self._state["appRequest"]
 
-        command = ("python -c \""
-                   "import os,sys,json;"
-                   "sys.stdout.write(json.dumps(os.environ.copy()));\"")
+        command = (
+            'python -c "'
+            'import os,sys,json;'
+            'sys.stdout.write(json.dumps(os.environ.copy(),ensure_ascii=0))"'
+        )
 
         def load(message):
-            env = json.loads(message)
-            self._state["testedEnvirons"][app_request] = env
-            self._models["diagnose"].load(env)
+            try:
+                env = json.loads(message)
+            except json.JSONDecodeError:
+                self.info(message)  # regular messages during resolve
+            else:
+                self._state["testedEnvirons"][app_request] = env
+                self._models["diagnose"].load(env)
 
         self.launch(command=command, stdout=load)
 

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -498,11 +498,11 @@ class Controller(QtCore.QObject):
 
             yield pkg
 
-    def env(self, request, use_filter=True):
+    def env(self, requests, use_filter=True):
         """Resolve context, relative Allzpark state
 
         Arguments:
-            request (str): Fully formatted request, including any
+            requests (list): Fully formatted request, including any
                 number of packages. E.g. "six==1.2 PySide2"
             use_filter (bool, optional): Whether or not to apply
                 the current package_filter
@@ -513,7 +513,7 @@ class Controller(QtCore.QObject):
         paths = self._package_paths()
 
         return rez.env(
-            request,
+            requests,
             package_paths=paths,
             package_filter=package_filter if use_filter else None
         )

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1162,6 +1162,12 @@ class Controller(QtCore.QObject):
 
         return pixmap
 
+    def shell_code(self):
+        app_request = self._state["appRequest"]
+        context = self._state["rezContexts"][app_request]
+        parent_env = self.parent_environ()
+        return context.get_shell_code(parent_environ=parent_env)
+
     def test_environment(self):
         app_request = self._state["appRequest"]
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -523,6 +523,7 @@ class Context(AbstractDockWidget):
         pages = {
             "context": QtWidgets.QWidget(),
             "graph": QtWidgets.QWidget(),
+            "code": QtWidgets.QWidget(),
         }
 
         widgets = {
@@ -531,6 +532,8 @@ class Context(AbstractDockWidget):
             "generateGraph": QtWidgets.QPushButton("Update"),
             "graphHotkeys": QtWidgets.QLabel(),
             "overlay": QtWidgets.QWidget(),
+            "code": QtWidgets.QPlainTextEdit(),
+            "printCode": QtWidgets.QPushButton("Get Shell Code"),
         }
 
         # Expose to CSS
@@ -553,13 +556,22 @@ class Context(AbstractDockWidget):
         layout.addWidget(widgets["generateGraph"])
         layout.addWidget(QtWidgets.QWidget(), 1)
 
+        layout = QtWidgets.QVBoxLayout(pages["code"])
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(widgets["code"])
+        layout.addWidget(widgets["printCode"])
+
         panels["central"].addTab(pages["context"], "Context")
         panels["central"].addTab(pages["graph"], "Graph")
+        panels["central"].addTab(pages["code"], "Code")
 
         ctrl.application_changed.connect(self.on_application_changed)
 
         widgets["overlay"].setParent(pages["graph"])
         widgets["overlay"].show()
+
+        widgets["code"].setObjectName("shellcode")
+        widgets["code"].setReadOnly(True)
 
         widgets["generateGraph"].clicked.connect(self.on_generate_clicked)
         widgets["graphHotkeys"].setText("""\
@@ -570,6 +582,7 @@ class Context(AbstractDockWidget):
             - <b>Zoom</b>: Right mouse + drag <br>
             - <b>Reset</b>: Double-click right mouse <br>
         """)
+        widgets["printCode"].clicked.connect(self.on_print_code_clicked)
 
         self._ctrl = ctrl
         self._panels = panels
@@ -603,7 +616,12 @@ class Context(AbstractDockWidget):
         self._widgets["graph"].setImage(pixmap)
         self._widgets["graph"]._pixmapHandle.setGraphicsEffect(None)
 
+    def on_print_code_clicked(self):
+        code = self._ctrl.shell_code()
+        self._widgets["code"].setPlainText(code)
+
     def on_application_changed(self):
+        self._widgets["code"].setPlainText("")
         if not self._widgets["graph"]._pixmapHandle:
             return
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -567,6 +567,9 @@ class Context(AbstractDockWidget):
 
         ctrl.application_changed.connect(self.on_application_changed)
 
+        widgets["view"].setSortingEnabled(True)
+        widgets["view"].sortByColumn(0, QtCore.Qt.AscendingOrder)
+
         widgets["overlay"].setParent(pages["graph"])
         widgets["overlay"].show()
 
@@ -672,9 +675,9 @@ class Environment(AbstractDockWidget):
         layout.addWidget(widgets["test"])
         layout.addWidget(widgets["compute"])
 
-        widgets["view"].setSortingEnabled(True)
-        widgets["penv"].setSortingEnabled(True)
-        widgets["test"].setSortingEnabled(True)
+        for view in ["view", "penv", "test"]:
+            widgets[view].setSortingEnabled(True)
+            widgets[view].sortByColumn(0, QtCore.Qt.AscendingOrder)
 
         pages["editor"].applied.connect(self.on_env_applied)
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -630,21 +630,29 @@ class Environment(AbstractDockWidget):
         pages = {
             "environment": QtWidgets.QWidget(),
             "editor": EnvironmentEditor(),
+            "penv": QtWidgets.QWidget(),
         }
 
         widgets = {
             "view": JsonView(),
+            "penv": JsonView(),
         }
 
         layout = QtWidgets.QVBoxLayout(pages["environment"])
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(widgets["view"])
 
+        layout = QtWidgets.QVBoxLayout(pages["penv"])
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(widgets["penv"])
+
         widgets["view"].setSortingEnabled(True)
+        widgets["penv"].setSortingEnabled(True)
 
         pages["editor"].applied.connect(self.on_env_applied)
 
         panels["central"].addTab(pages["environment"], "Context")
+        panels["central"].addTab(pages["penv"], "Parent")
         panels["central"].addTab(pages["editor"], "User")
 
         user_env = ctrl.state.retrieve("userEnv", {})
@@ -662,6 +670,12 @@ class Environment(AbstractDockWidget):
         proxy_model = QtCore.QSortFilterProxyModel()
         proxy_model.setSourceModel(model_)
         self._widgets["view"].setModel(proxy_model)
+
+        parent_env_model = model.EnvironmentModel()
+        proxy_model = QtCore.QSortFilterProxyModel()
+        proxy_model.setSourceModel(parent_env_model)
+        self._widgets["penv"].setModel(proxy_model)
+        parent_env_model.load(self._ctrl.state["parentEnviron"].copy())
 
     def on_env_applied(self, env):
         self._ctrl.state.store("userEnv", env)

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -77,6 +77,8 @@ class App(AbstractDockWidget):
         self.setAttribute(QtCore.Qt.WA_StyledBackground)
         self.setObjectName("App")
 
+        default_app_icon = res.pixmap("Alert_Info_32")
+
         panels = {
             "central": QtWidgets.QWidget(),
             "shortcuts": QtWidgets.QWidget(),
@@ -142,7 +144,7 @@ class App(AbstractDockWidget):
         layout.setRowStretch(15, 1)
         layout.addWidget(panels["footer"], 40, 0, 1, 2)
 
-        widgets["icon"].setPixmap(res.pixmap("Alert_Info_32"))
+        widgets["icon"].setPixmap(default_app_icon)
         widgets["environment"].setIcon(res.icon(Environment.icon))
         widgets["packages"].setIcon(res.icon(Packages.icon))
         widgets["terminal"].setIcon(res.icon(Console.icon))
@@ -159,6 +161,7 @@ class App(AbstractDockWidget):
         self._panels = panels
         self._widgets = widgets
         self._proxy = proxy_model
+        self._default_app_icon = default_app_icon
 
         self.setWidget(panels["central"])
 
@@ -186,6 +189,8 @@ class App(AbstractDockWidget):
         if icon:
             icon = icon.pixmap(QtCore.QSize(px(32), px(32)))
             self._widgets["icon"].setPixmap(icon)
+        else:
+            self._widgets["icon"].setPixmap(self._default_app_icon)
 
         self._widgets["label"].setText(name)
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -10,6 +10,7 @@ from .vendor.Qt import QtWidgets, QtCore, QtGui, QtCompat
 from .vendor import qargparse, QtImageViewer
 
 from . import resources as res, model, delegates, util
+from . import _rezapi as rez
 from . import allzparkconfig
 
 try:
@@ -537,7 +538,7 @@ class Context(AbstractDockWidget):
             "generateGraph": QtWidgets.QPushButton("Update"),
             "graphHotkeys": QtWidgets.QLabel(),
             "overlay": QtWidgets.QWidget(),
-            "code": QtWidgets.QPlainTextEdit(),
+            "code": QtWidgets.QTextEdit(),
             "printCode": QtWidgets.QPushButton("Get Shell Code"),
         }
 
@@ -626,7 +627,15 @@ class Context(AbstractDockWidget):
 
     def on_print_code_clicked(self):
         code = self._ctrl.shell_code()
-        self._widgets["code"].setPlainText(code)
+        comment = "REM " if rez.system.shell == "cmd" else "# "
+
+        pretty = []
+        for ln in code.split("\n"):
+            level = logging.DEBUG if ln.startswith(comment) else logging.INFO
+            color = "<font color=\"%s\">" % res.log_level_color(level)
+            pretty.append("%s%s</font>" % (color, ln.replace(" ", "&nbsp;")))
+
+        self._widgets["code"].setText("<br>".join(pretty))
 
     def on_application_changed(self):
         self._widgets["code"].setPlainText("")

--- a/allzpark/resources/style-dark.css
+++ b/allzpark/resources/style-dark.css
@@ -389,6 +389,11 @@ Context #overlay {
     min-height: 150px;
 }
 
+Context #shellcode {
+    font-family: "JetBrains Mono";
+    font-size: 11px;
+}
+
 QDockWidget {
     background: %(prim)s;
     border: 1px solid %(dim)s;

--- a/allzpark/resources/style-light.css
+++ b/allzpark/resources/style-light.css
@@ -385,6 +385,11 @@ Context #overlay {
     min-height: 150px;
 }
 
+Context #shellcode {
+    font-family: "JetBrains Mono";
+    font-size: 11px;
+}
+
 QDockWidget {
     background: %(prim)s;
     border: 1px solid %(dim)s;

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -248,7 +248,9 @@ class Window(QtWidgets.QMainWindow):
                                     ctrl.models["profileVersions"])
         docks["packages"].set_model(ctrl.models["packages"])
         docks["context"].set_model(ctrl.models["context"])
-        docks["environment"].set_model(ctrl.models["environment"])
+        docks["environment"].set_model(ctrl.models["environment"],
+                                       ctrl.models["parentenv"],
+                                       ctrl.models["diagnose"])
         docks["commands"].set_model(ctrl.models["commands"])
 
         proxy_model = model.ProxyModel(ctrl.models["apps"])


### PR DESCRIPTION
### Feature Propose

Allow to provide unified application launching environment from `allzparkconfig.py`.

### Motivation

Allzpark can be launched in various way, e.g. from a Python virtual environment, or a Rez resolved context. And Allzpark can be backed with `bleeding-rez` or `nerdvegas/rez`, which has a bit different base environment control scheme between two approaches.

To overcome those differences and other surprises, allowing subprocess (application) parent environment to be set in `allzparkconfig.py` would be the most straight forward and effective solution.

### Additional Features

* Add "Parent" tab in "Environment" dock page to show current parent environment.
* Add "Diagnose" tab in "Environment" dock page to show actual subprocess environment.
* Add "Code" tab in "Context" dock page to show script that is used to spawn shell from resolved context.

![ca88084c-cc0f-4d0a-8246-a92b294a037e](https://user-images.githubusercontent.com/3357009/98040854-f834d000-1e5b-11eb-8992-1f3797af478a.gif)
