### PR TITLE
Minor fixes and adding tests for those fixes

### DIFF
--- a/allzpark/_rezapi.py
+++ b/allzpark/_rezapi.py
@@ -47,7 +47,7 @@ def find_latest(name, range_=None, paths=None):
 
 
 try:
-    from rez import project
+    from rez import __project__ as project
 except ImportError:
     # nerdvegas/rez
     project = "rez"

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -844,7 +844,7 @@ class Controller(QtCore.QObject):
                 profiles = root()
 
             except Exception:
-                if log.level == logging.DEBUG:
+                if log.level < logging.INFO:
                     traceback.print_exc()
 
                 self.error("Could not find profiles in %s" % root)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,6 +102,7 @@ jobs:
         displayName: "Setup Xvfb"
 
       - script: |
+          export DISPLAY=:99
           xvfb-run sudo nosetests
         displayName: "Run tests"
 

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -31,11 +31,11 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        self.ctrl.reset(["foo"])
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo"])
 
-        self.ctrl.select_profile("foo")
-        util.wait(self.ctrl.state_changed, "ready")
+        with util.wait_signal(self.ctrl.state_changed, "ready"):
+            self.ctrl.select_profile("foo")
 
         env = self.ctrl.state["rezEnvirons"]
 
@@ -80,11 +80,11 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        self.ctrl.reset(["foo"])
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo"])
 
-        self.ctrl.select_profile("foo")
-        util.wait(self.ctrl.state_changed, "ready")
+        with util.wait_signal(self.ctrl.state_changed, "ready"):
+            self.ctrl.select_profile("foo")
 
         env = self.ctrl.state["rezEnvirons"]
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -22,11 +22,11 @@ class TestLaunch(util.TestBase):
                 }
             },
         })
-        self.ctrl.reset(["foo"])
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo"])
 
-        self.ctrl.select_profile("foo")
-        util.wait(self.ctrl.state_changed, "ready")
+        with util.wait_signal(self.ctrl.state_changed, "ready"):
+            self.ctrl.select_profile("foo")
 
         self.ctrl.select_application("app==1")
         self.assertEqual("app==1", self.ctrl.state["appRequest"])
@@ -42,13 +42,15 @@ class TestLaunch(util.TestBase):
           'sys.stdout.write(\'meow\')"'
         ) % sys.executable
 
-        self.ctrl.launch(command=command,
-                         stdout=lambda m: stdout.append(m),
-                         stderr=lambda m: stderr.append(m))
+        with util.wait_signal(self.ctrl.state_changed, "launching"):
+            self.ctrl.launch(command=command,
+                             stdout=lambda m: stdout.append(m),
+                             stderr=lambda m: stderr.append(m))
 
-        util.wait(self.ctrl.state_changed, "launching")
         self.assertEqual(len(commands), 1)
 
-        util.wait(commands[0].killed)
+        with util.wait_signal(commands[0].killed):
+            pass
+
         self.assertIn("meow", "\n".join(stdout))
         self.assertEqual("", "\n".join(stderr))

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,54 @@
+
+import sys
+from tests import util
+
+
+class TestLaunch(util.TestBase):
+
+    def test_launch_subprocess(self):
+        """Test launching subprocess command"""
+        util.memory_repository({
+            "foo": {
+                "1": {
+                    "name": "foo",
+                    "version": "1",
+                    "requires": ["~app"],
+                }
+            },
+            "app": {
+                "1": {
+                    "name": "app",
+                    "version": "1",
+                }
+            },
+        })
+        self.ctrl.reset(["foo"])
+        util.wait(self.ctrl.resetted)
+
+        self.ctrl.select_profile("foo")
+        util.wait(self.ctrl.state_changed, "ready")
+
+        self.ctrl.select_application("app==1")
+        self.assertEqual("app==1", self.ctrl.state["appRequest"])
+
+        commands = self.ctrl.state["commands"]
+        self.assertEqual(len(commands), 0)
+
+        stdout = list()
+        stderr = list()
+        command = (
+          '%s -c "'
+          'import sys;'
+          'sys.stdout.write(\'meow\')"'
+        ) % sys.executable
+
+        self.ctrl.launch(command=command,
+                         stdout=lambda m: stdout.append(m),
+                         stderr=lambda m: stderr.append(m))
+
+        util.wait(self.ctrl.state_changed, "launching")
+        self.assertEqual(len(commands), 1)
+
+        util.wait(commands[0].killed)
+        self.assertIn("meow", "\n".join(stdout))
+        self.assertEqual("", "\n".join(stderr))

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,4 +1,5 @@
 
+from unittest import mock
 from tests import util
 
 
@@ -100,3 +101,38 @@ class TestProfiles(util.TestBase):
             ],
             list(self.ctrl.state["rezApps"].keys())
         )
+
+    def test_profile_listing_without_root_err(self):
+        """Listing profile without root will raise AssertionError"""
+        self.assertRaises(AssertionError, self.ctrl.reset)
+        self.assertRaises(AssertionError, self.ctrl.list_profiles)
+
+    def test_profile_listing_callable_root_err(self):
+        """Listing profile with bad callable will prompt error message"""
+        import traceback
+        import logging
+        from allzpark import control
+
+        traceback.print_exc = mock.MagicMock(name="traceback.print_exc")
+        self.ctrl.error = mock.MagicMock(name="Controller.error")
+
+        def bad_root():
+            raise Exception("This should be caught.")
+        self.ctrl.list_profiles(bad_root)
+
+        # ctrl.error must be called in all cases
+        self.ctrl.error.assert_called_once()
+        # traceback.print_exc should be called if logging level is set
+        # lower than INFO, e.g. DEBUG or NOTSET
+        if control.log.level < logging.INFO:
+            traceback.print_exc.assert_called_once()
+
+    def test_profile_listing_invalid_type_root_err(self):
+        """Listing profile with invalid input type will raise TypeError"""
+        self.assertRaises(TypeError, self.ctrl.list_profiles, {"foo"})
+
+    def test_profile_listing_filter_out_empty_names(self):
+        """Listing profile with empty names will be filtered"""
+        expected = ["foo", "bar"]
+        profiles = self.ctrl.list_profiles(expected + [None, ""])
+        self.assertEqual(profiles, expected)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -22,9 +22,8 @@ class TestProfiles(util.TestBase):
                 }
             }
         })
-        self.ctrl.reset(["foo", "bar"])
-
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo", "bar"])
 
         # last profile will be selected by default
         self.assertEqual("bar", self.ctrl.state["profileName"])
@@ -47,12 +46,13 @@ class TestProfiles(util.TestBase):
                 }
             }
         })
-        self.ctrl.reset(["foo", "bar"])
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo", "bar"])
 
-        self.ctrl.select_profile("foo")
-        # enter 'noapps' state
-        util.wait(self.ctrl.state_changed, "noapps")
+        with util.wait_signal(self.ctrl.state_changed, "noapps"):
+            self.ctrl.select_profile("foo")
+            # wait enter 'noapps' state
+
         self.assertEqual("foo", self.ctrl.state["profileName"])
 
     def test_profile_list_apps(self):
@@ -89,11 +89,12 @@ class TestProfiles(util.TestBase):
                 }
             },
         })
-        self.ctrl.reset(["foo"])
-        util.wait(self.ctrl.resetted)
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo"])
 
-        self.ctrl.select_profile("foo")
-        util.wait(self.ctrl.state_changed, "ready")
+        with util.wait_signal(self.ctrl.state_changed, "ready"):
+            self.ctrl.select_profile("foo")
+
         self.assertEqual(
             [
                 "app_A==1.0.0",


### PR DESCRIPTION
### Fixes

* When logging level is `NOTSET` (the default), traceback doesn't get printed when exception raised from listing profile. Which I think it should ?

* `bleeding-rez` doesn't have attribute `project` but `__project__`. Now the `rez.project` can function properly.

### Tests

A few test cases has been added to reflect the above fixes.