### PR TITLE
Make unresolvable App fails independently

### DIFF
--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -341,9 +341,7 @@ class Controller(QtCore.QObject):
                 environ = context.get_environ(parent_environ=parent_env)
 
             except rez.ResolvedContextError:
-                return {
-                    "error": "Failed context"
-                }
+                return model.BrokenContext.broken_dict.copy()
             else:
                 env[app_request] = environ
                 return environ

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -596,6 +596,8 @@ class Controller(QtCore.QObject):
         root = root or self._state["root"]
         assert root, "Tried resetting without a root, this is a bug"
 
+        self._state.to_booting()
+
         def do():
             profiles = dict()
             default_profile = None
@@ -672,7 +674,7 @@ class Controller(QtCore.QObject):
         # so that we can pick up new packages.
         rez.clear_caches()
 
-        self._state.to_booting()
+        self._state.to_loading()
         util.defer(
             do,
             on_success=_on_success,

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -651,7 +651,7 @@ class Controller(QtCore.QObject):
             self._state.to_ready()
             self.resetted.emit()
 
-        def _on_success():
+        def _on_success(result=None):
             profile = not self._state["profileName"]
 
             if profile:
@@ -791,7 +791,7 @@ class Controller(QtCore.QObject):
                 self.debug("Cleaning up..")
                 shutil.rmtree(tempdir)
 
-        def on_success(result):
+        def on_success(result=None):
             self.repository_changed.emit()
 
         def on_failure(error, trace):
@@ -808,7 +808,7 @@ class Controller(QtCore.QObject):
             self.debug("Delocalizing %s" % package.root)
             localz.delocalize(package)
 
-        def on_success(result):
+        def on_success(result=None):
             self.repository_changed.emit()
 
         def on_failure(error, trace):

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1106,7 +1106,8 @@ class Controller(QtCore.QObject):
 
                 try:
                     context = self.env(request)
-                except rez.PackageFamilyNotFoundError as err:
+                except (rez.PackageFamilyNotFoundError,
+                        rez.PackageNotFoundError) as err:
                     self.error("Resolve failed: %s" % str(err))
                     context = model.BrokenContext(app_package.name,
                                                   request)
@@ -1122,7 +1123,8 @@ class Controller(QtCore.QObject):
                                 "patchWithFilter", False
                             )
                         )
-                    except rez.PackageFamilyNotFoundError as err:
+                    except (rez.PackageFamilyNotFoundError,
+                            rez.PackageNotFoundError) as err:
                         self.error("Patch failed: %s" % str(err))
                         context = model.BrokenContext(app_package.name,
                                                       request)
@@ -1159,12 +1161,18 @@ class Controller(QtCore.QObject):
                         "Please report this to "
                         "https://github.com/mottosso/allzpark/issues/66"
                     )
-
-                self.error(
-                    "Context for '%s' had no resolved packages, this is "
-                    "likely due to a version conflict and broken resolve. "
-                    "Try graphing it." % app_request
-                )
+                    self.error(
+                        "Context for '%s' had no resolved packages, this is "
+                        "likely due to a version conflict and broken resolve. "
+                        "Try graphing it." % app_request
+                    )
+                else:
+                    self.error(
+                        "Context for '%s' had no resolved packages, failure "
+                        "reason as follow:\n===\n%s\n===\nIf above description "
+                        "isn't clear, try graphing it." %
+                        (app_request, rez_context.failure_description)
+                    )
 
             self._state["rezApps"][app_request] = rez_pkg
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -183,6 +183,16 @@ class App(AbstractDockWidget):
         if arg["name"] == "tool":
             ctrl.select_tool(value)
 
+    def on_state_appok(self):
+        launch_btn = self._widgets["launchBtn"]
+        launch_btn.setEnabled(True)
+        launch_btn.setText("Launch")
+
+    def on_state_appfailed(self):
+        launch_btn = self._widgets["launchBtn"]
+        launch_btn.setEnabled(False)
+        launch_btn.setText("Application Broken")
+
     def refresh(self, index):
         name = index.data(QtCore.Qt.DisplayRole)
         icon = index.data(QtCore.Qt.DecorationRole)
@@ -371,6 +381,12 @@ class Packages(AbstractDockWidget):
                 override_count,
                 disabled_count,
             ))
+
+    def on_state_appfailed(self):
+        self._widgets["view"].setEnabled(False)
+
+    def on_state_appok(self):
+        self._widgets["view"].setEnabled(True)
 
     def on_right_click(self, position):
         view = self._widgets["view"]
@@ -607,11 +623,13 @@ class Context(AbstractDockWidget):
         self._widgets["view"].setModel(proxy_model)
         self._model = model_
 
-        model_.modelReset.connect(self.on_context_loaded)
+    def on_state_appfailed(self):
+        self._widgets["generateGraph"].setEnabled(False)
+        self._widgets["printCode"].setEnabled(False)
 
-    def on_context_loaded(self):
-        self._widgets["generateGraph"].setEnabled(not self._model.is_broken)
-        self._widgets["printCode"].setEnabled(not self._model.is_broken)
+    def on_state_appok(self):
+        self._widgets["generateGraph"].setEnabled(True)
+        self._widgets["printCode"].setEnabled(True)
 
     def on_generate_clicked(self):
         pixmap = self._ctrl.graph()
@@ -739,11 +757,11 @@ class Environment(AbstractDockWidget):
         self._widgets["test"].setModel(proxy_model)
         self._models["diagnose"] = diagnose
 
-        environ.modelReset.connect(self.on_environ_loaded)
+    def on_state_appfailed(self):
+        self._widgets["compute"].setEnabled(False)
 
-    def on_environ_loaded(self):
-        environ = self._models["environ"]
-        self._widgets["compute"].setEnabled(not environ.is_broken)
+    def on_state_appok(self):
+        self._widgets["compute"].setEnabled(True)
 
     def on_env_applied(self, env):
         self._ctrl.state.store("userEnv", env)

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -607,6 +607,12 @@ class Context(AbstractDockWidget):
         self._widgets["view"].setModel(proxy_model)
         self._model = model_
 
+        model_.modelReset.connect(self.on_context_loaded)
+
+    def on_context_loaded(self):
+        self._widgets["generateGraph"].setEnabled(not self._model.is_broken)
+        self._widgets["printCode"].setEnabled(not self._model.is_broken)
+
     def on_generate_clicked(self):
         pixmap = self._ctrl.graph()
 
@@ -711,19 +717,33 @@ class Environment(AbstractDockWidget):
         self._panels = panels
         self._pages = pages
         self._widgets = widgets
+        self._models = {
+            "environ": None,
+            "parent": None,
+            "diagnose": None,
+        }
 
     def set_model(self, environ, parent, diagnose):
         proxy_model = QtCore.QSortFilterProxyModel()
         proxy_model.setSourceModel(environ)
         self._widgets["view"].setModel(proxy_model)
+        self._models["environ"] = environ
 
         proxy_model = QtCore.QSortFilterProxyModel()
         proxy_model.setSourceModel(parent)
         self._widgets["penv"].setModel(proxy_model)
+        self._models["parent"] = parent
 
         proxy_model = QtCore.QSortFilterProxyModel()
         proxy_model.setSourceModel(diagnose)
         self._widgets["test"].setModel(proxy_model)
+        self._models["diagnose"] = diagnose
+
+        environ.modelReset.connect(self.on_environ_loaded)
+
+    def on_environ_loaded(self):
+        environ = self._models["environ"]
+        self._widgets["compute"].setEnabled(not environ.is_broken)
 
     def on_env_applied(self, env):
         self._ctrl.state.store("userEnv", env)

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -611,6 +611,7 @@ class Context(AbstractDockWidget):
 
         self._ctrl = ctrl
         self._panels = panels
+        self._pages = pages
         self._widgets = widgets
         self._model = None
 

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -576,14 +576,7 @@ class JsonModel(qjsonmodel.QJsonModel):
 
 
 class EnvironmentModel(JsonModel):
-
-    def __init__(self, *args, **kwargs):
-        super(EnvironmentModel, self).__init__(*args, **kwargs)
-        self.is_broken = False
-
     def load(self, data):
-        self.is_broken = data == BrokenContext.broken_dict
-
         # Convert PATH environment variables to lists
         # for improved viewing experience
         for key, value in data.copy().items():
@@ -595,14 +588,7 @@ class EnvironmentModel(JsonModel):
 
 
 class ContextModel(JsonModel):
-
-    def __init__(self, *args, **kwargs):
-        super(ContextModel, self).__init__(*args, **kwargs)
-        self.is_broken = False
-
-    def load(self, data):
-        self.is_broken = data == BrokenContext.broken_dict
-        super(ContextModel, self).load(data)
+    pass
 
 
 class TriStateSortFilterProxyModel(QtCore.QSortFilterProxyModel):

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -383,7 +383,7 @@ class PackagesModel(AbstractTableModel):
             versions = sorted(
                 [str(v.version) for v in versions],
                 key=util.natural_keys
-            )
+            ) or [version]  # broken package
 
             if localz:
                 relocatable = localz.is_relocatable(pkg)

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -284,6 +284,7 @@ class BrokenPackage(object):
 
         self.name = request.name
         self.version = versions[-1]
+        self.qualified_name = "%s-%s" % (self.name, str(self.version))
         self.uri = ""
         self.root = ""
         self.relocatable = False

--- a/allzpark/util.py
+++ b/allzpark/util.py
@@ -128,7 +128,8 @@ else:
         try:
             result = target(*(args or []), **(kwargs or {}))
         except Exception as e:
-            on_failure(e)
+            error = traceback.format_exc()
+            on_failure(e, error)
         else:
             on_success(result)
 

--- a/allzpark/vendor/qargparse.py
+++ b/allzpark/vendor/qargparse.py
@@ -5,7 +5,7 @@ import logging
 from collections import OrderedDict as odict
 from Qt import QtCore, QtWidgets, QtGui
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 _log = logging.getLogger(__name__)
 _type = type  # used as argument
 
@@ -269,7 +269,6 @@ class Boolean(QArgument):
     """
     def create(self):
         widget = QtWidgets.QCheckBox()
-        widget.clicked.connect(self.changed.emit)
 
         if isinstance(self, Tristate):
             self._read = lambda: widget.checkState()

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -31,12 +31,12 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
 
         env = self.ctrl.state["rezEnvirons"]
@@ -82,12 +82,12 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
 
         env = self.ctrl.state["rezEnvirons"]
@@ -134,9 +134,9 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
@@ -160,9 +160,9 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
@@ -193,9 +193,9 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
@@ -220,9 +220,9 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==2"]

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -33,6 +33,8 @@ class TestApps(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         with util.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
@@ -82,6 +84,8 @@ class TestApps(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         with util.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
@@ -130,9 +134,10 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        # should be in ready state
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -155,9 +160,10 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        # should be in ready state
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -187,9 +193,10 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        # should be in ready state
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -213,9 +220,10 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        # should be in ready state
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==2"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]

--- a/tests/test_docks.py
+++ b/tests/test_docks.py
@@ -19,9 +19,9 @@ class TestDocks(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
@@ -34,7 +34,7 @@ class TestDocks(util.TestBase):
 
         for app, state in {"app_A==None": False, "app_B==1": True}.items():
             self.ctrl.select_application(app)
-            util.wait(100)
+            self.wait(100)
 
             dock = self.show_dock("environment", on_page="diagnose")
             self.assertEqual(dock._widgets["compute"].isEnabled(), state)

--- a/tests/test_docks.py
+++ b/tests/test_docks.py
@@ -1,0 +1,49 @@
+
+from tests import util
+
+
+class TestDocks(util.TestBase):
+
+    def test_feature_blocked_on_failed_app(self):
+        """Test feature blocked if application is broken"""
+        util.memory_repository({
+            "foo": {
+                "1.0.0": {
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "requires": [
+                        "~app_A",  # missing package (broken app)
+                        "~app_B",
+                    ],
+                },
+            },
+            "app_B": {"1": {"name": "app_B", "version": "1"}},
+        })
+        with util.wait_signal(self.ctrl.resetted):
+            self.ctrl.reset(["foo"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
+
+        context_a = self.ctrl.state["rezContexts"]["app_A==None"]
+        context_b = self.ctrl.state["rezContexts"]["app_B==1"]
+
+        self.assertFalse(context_a.success)
+        self.assertTrue(context_b.success)
+
+        self.show_advance_controls()
+
+        for app, state in {"app_A==None": False, "app_B==1": True}.items():
+            self.ctrl.select_application(app)
+            util.wait(100)
+
+            dock = self.show_dock("environment", on_page="diagnose")
+            self.assertEqual(dock._widgets["compute"].isEnabled(), state)
+
+            dock = self.show_dock("context", on_page="graph")
+            self.assertEqual(dock._widgets["generateGraph"].isEnabled(), state)
+
+            dock = self.show_dock("context", on_page="code")
+            self.assertEqual(dock._widgets["printCode"].isEnabled(), state)
+
+            dock = self.show_dock("app")
+            self.assertEqual(dock._widgets["launchBtn"].isEnabled(), state)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -22,12 +22,12 @@ class TestLaunch(util.TestBase):
                 }
             },
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
 
         self.ctrl.select_application("app==1")
@@ -44,14 +44,14 @@ class TestLaunch(util.TestBase):
           'sys.stdout.write(\'meow\')"'
         ) % sys.executable
 
-        with util.wait_signal(self.ctrl.state_changed, "launching"):
+        with self.wait_signal(self.ctrl.state_changed, "launching"):
             self.ctrl.launch(command=command,
                              stdout=lambda m: stdout.append(m),
                              stderr=lambda m: stderr.append(m))
 
         self.assertEqual(len(commands), 1)
 
-        with util.wait_signal(commands[0].killed):
+        with self.wait_signal(commands[0].killed):
             pass
 
         self.assertIn("meow", "\n".join(stdout))

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -24,6 +24,8 @@ class TestLaunch(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         with util.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -22,9 +22,9 @@ class TestProfiles(util.TestBase):
                 }
             }
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo", "bar"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "noapps")
 
         # last profile will be selected by default
@@ -48,12 +48,12 @@ class TestProfiles(util.TestBase):
                 }
             }
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo", "bar"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "noapps")
 
-        with util.wait_signal(self.ctrl.state_changed, "noapps"):
+        with self.wait_signal(self.ctrl.state_changed, "noapps"):
             self.ctrl.select_profile("foo")
             # wait enter 'noapps' state
 
@@ -93,12 +93,12 @@ class TestProfiles(util.TestBase):
                 }
             },
         })
-        with util.wait_signal(self.ctrl.resetted):
+        with self.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
-        util.wait(timeout=200)
+        self.wait(timeout=200)
         self.assertEqual(self.ctrl.state.state, "ready")
 
-        with util.wait_signal(self.ctrl.state_changed, "ready"):
+        with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
 
         self.assertEqual(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -24,6 +24,8 @@ class TestProfiles(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo", "bar"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "noapps")
 
         # last profile will be selected by default
         self.assertEqual("bar", self.ctrl.state["profileName"])
@@ -48,6 +50,8 @@ class TestProfiles(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo", "bar"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "noapps")
 
         with util.wait_signal(self.ctrl.state_changed, "noapps"):
             self.ctrl.select_profile("foo")
@@ -91,6 +95,8 @@ class TestProfiles(util.TestBase):
         })
         with util.wait_signal(self.ctrl.resetted):
             self.ctrl.reset(["foo"])
+        util.wait(timeout=200)
+        self.assertEqual(self.ctrl.state.state, "ready")
 
         with util.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")

--- a/tests/util.py
+++ b/tests/util.py
@@ -41,7 +41,11 @@ def wait(timeout=1000):
     loop = QtCore.QEventLoop()
     timer = QtCore.QTimer()
 
-    timer.timeout.connect(loop.quit)
+    def on_timeout():
+        timer.stop()
+        loop.quit()
+
+    timer.timeout.connect(on_timeout)
     timer.start(timeout)
     loop.exec_()
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -26,6 +26,26 @@ class TestBase(unittest.TestCase):
         wait(timeout=500)
         self.window.close()
 
+    def show_advance_controls(self):
+        preferences = self.window._docks["preferences"]
+        arg = next(opt for opt in preferences.options
+                   if opt["name"] == "showAdvancedControls")
+        arg.write(True)
+
+    def show_dock(self, name, on_page=None):
+        dock = self.window._docks[name]
+        dock.toggle.setChecked(True)
+        dock.toggle.clicked.emit()
+        wait(timeout=200)
+
+        if on_page is not None:
+            tabs = dock._panels["central"]
+            page = dock._pages[on_page]
+            index = tabs.indexOf(page)
+            tabs.tabBar().setCurrentIndex(index)
+
+        return dock
+
 
 def memory_repository(packages):
     from allzpark import _rezapi as rez


### PR DESCRIPTION
### Problem

If an application package is missing or it's dependency is missing, will raise `PackageFamilyNotFoundError` or `PackageNotFoundError` and failling whole profile.

<details><summary> Screenshot </summary>

![image](https://user-images.githubusercontent.com/3357009/98543396-6a2e6e80-22cd-11eb-99d5-9d5d52d81428.png)

</details>

### Proposal

I think it could be more atomic, handling application that have missing packages, and continue to resolve other.

<details><summary> Screenshot </summary>

![image](https://user-images.githubusercontent.com/3357009/98543339-4ff49080-22cd-11eb-9bab-2b03d12ca917.png)

</details>

### Additional Improvement

Features like, launching application tool, diagnose environment, graphing resolved context,.. will be blocked if selected application is broken (resolve failed).

### Implementation details

* Profile package will be resolved solely at first, then resolve with each app if profile itself is solvable.
* Some of the checkBox widgets which created with `qargparse.py` were emitting value changed signal twice in one click, which may trigger data model reset twice and leads to crash. E.g. "Use Development Pakcages" check box. Updating `qargparse.py` fixed the issue.
* Two controller state were added, `appfailed` and `appok`, for triggering feature block/unblock.
* Added more tests with a bit improvement. Running tests on Azure DevOps are much stable now, but there are still have a little chance occurring `Segmentation fault` on Ubuntu. I have got Ubuntu installed on my Windows with WSL2 and running tests locally, still not able to reproduce that `Segmentation fault`. :/
