### PR TITLE
Implement #127 and #96

### DIFF
--- a/allzpark/allzparkconfig.py
+++ b/allzpark/allzparkconfig.py
@@ -103,6 +103,29 @@ def metadata_from_package(variant):
     })
 
 
+def protected_preferences():
+    """Protect preference settings
+
+    Prevent clueless one from touching danger settings.
+
+    Following is a list of preference names that you may lock:
+    * showAllApps (bool)
+    * showHiddenApps (bool)
+    * showAllVersions (bool)
+    * patchWithFilter (bool)
+    * clearCacheTimeout (int)
+    * exclusionFilter (str)
+
+    This should return a preference name and default value paired
+    dict. For example: {"showAllVersions": False}
+
+    Returns:
+        dict
+
+    """
+    return dict()
+
+
 def themes():
     """Allzpark GUI theme list provider
 

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1216,7 +1216,7 @@ class Controller(QtCore.QObject):
                 key=util.natural_keys
             )
             resolved_packages = [
-                pkg for pkg in contexts[request].resolved_packages
+                pkg for pkg in contexts[request].resolved_packages or []
                 if pkg.name != package.name
             ]
             visible_apps[request] = {

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -356,16 +356,25 @@ class Controller(QtCore.QObject):
                 return environ
 
     def resolved_packages(self, app_request):
+        """Return context resolved packages and versions
+
+        If preference 'showAllVersions' is enabled, all packages' versions
+        will be collected, except profile. Profile version should not be
+        changed from Packages view, should be changed from Profile view.
+
+        """
         all_vers = self._state.retrieve("showAllVersions", False)
         profile_name = self._state["profileName"]
         resolved = self._state["rezContexts"][app_request].resolved_packages
+
         packages = odict()  # keep resolved order
         for pkg in resolved or []:
-            # profile version should not be changed in Packages view
-            _all_vers = all_vers and pkg.name != profile_name
+            is_profile = pkg.name == profile_name
+            all_vers_ = all_vers and not is_profile
+
             versions = [
                 str(p.version)
-                for p in (self.find(pkg.name) if _all_vers else [pkg])
+                for p in (self.find(pkg.name) if all_vers_ else [pkg])
             ]
             packages[pkg.name] = {
                 "package": pkg,

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1159,6 +1159,9 @@ class Controller(QtCore.QObject):
         contexts = odict()
         with util.timing() as t:
 
+            current_app = self._state["appRequest"] or ""
+            current_app = current_app.split("==", 1)[0]
+
             for app_request in apps:
 
                 app_package = _try_finding_latest_app(app_request)
@@ -1181,10 +1184,14 @@ class Controller(QtCore.QObject):
                                                    app_package.name,
                                                    mode="Patch")
 
-                    # update context key `app_request` if patched
+                    # update context key `app_request` if patched, and
+                    # update startup app
                     for pkg in context.resolved_packages or []:
                         if pkg.name == app_package.name:
                             app_request = "%s==%s" % (pkg.name, pkg.version)
+                            if pkg.name == current_app:
+                                self._state.store("startupApplication",
+                                                  app_request)
                             break
 
                 contexts[app_request] = context

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1184,15 +1184,17 @@ class Controller(QtCore.QObject):
                                                    app_package.name,
                                                    mode="Patch")
 
-                    # update context key `app_request` if patched, and
-                    # update startup app
-                    for pkg in context.resolved_packages or []:
-                        if pkg.name == app_package.name:
-                            app_request = "%s==%s" % (pkg.name, pkg.version)
-                            if pkg.name == current_app:
-                                self._state.store("startupApplication",
-                                                  app_request)
-                            break
+                # To avoid application selection change on patched or
+                # set back to default:
+                #   1. update context key `app_request`, and
+                #   2. update startup app
+                for pkg in context.resolved_packages or []:
+                    if pkg.name == app_package.name:
+                        app_request = "%s==%s" % (pkg.name, pkg.version)
+                        if pkg.name == current_app:
+                            self._state.store("startupApplication",
+                                              app_request)
+                        break
 
                 contexts[app_request] = context
 

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -205,6 +205,7 @@ class Controller(QtCore.QObject):
         _State("resolving", help="Rez is busy resolving a context"),
         _State("loading", help="Something is taking a moment"),
         _State("errored", help="Something has gone wrong"),
+        _State("console", help="Something need you to read"),
         _State("launching", help="An application is launching"),
         _State("ready", help="Awaiting user input"),
         _State("noprofiles", help="Allzpark did not find any profiles at all"),
@@ -1237,6 +1238,12 @@ class Controller(QtCore.QObject):
 
     def graph(self):
         context = self._state["rezContexts"][self._state["appRequest"]]
+        if isinstance(context, model.BrokenContext):
+            self._state.to_console()
+            self._state.to_ready()
+            self.error("Can not graph a broken context.")
+            return
+
         graph_str = context.graph(as_dot=True)
 
         tempdir = tempfile.mkdtemp()

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -751,8 +751,8 @@ class Controller(QtCore.QObject):
                 "This is a bug"
             )
 
-            overrides = self._models["packages"].overrides
-            disabled = self._models["packages"].disabled
+            overrides = self._models["packages"]._overrides
+            disabled = self._models["packages"]._disabled
             environ = self.parent_environ()
 
             self.debug(
@@ -1008,13 +1008,6 @@ class Controller(QtCore.QObject):
         self.update_command()
         self._state.store("startupApplication", app_request)
         self.application_changed.emit()
-
-        if context.success:
-            self._state.to_appok()
-        else:
-            self._state.to_appfailed()
-
-        self._state.to_ready()
 
         if context.success:
             self._state.to_appok()

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -1188,13 +1188,14 @@ class Controller(QtCore.QObject):
                 # set back to default:
                 #   1. update context key `app_request`, and
                 #   2. update startup app
-                for pkg in context.resolved_packages or []:
-                    if pkg.name == app_package.name:
-                        app_request = "%s==%s" % (pkg.name, pkg.version)
-                        if pkg.name == current_app:
-                            self._state.store("startupApplication",
-                                              app_request)
-                        break
+                if context.success:
+                    for pkg in context.resolved_packages or []:
+                        if pkg.name == app_package.name:
+                            app_request = "%s==%s" % (pkg.name, pkg.version)
+                            if pkg.name == current_app:
+                                self._state.store("startupApplication",
+                                                  app_request)
+                            break
 
                 contexts[app_request] = context
 

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -362,10 +362,10 @@ class Controller(QtCore.QObject):
         packages = odict()  # keep resolved order
         for pkg in resolved or []:
             # profile version should not be changed in Packages view
-            _all_vers = pkg.name != profile_name
+            _all_vers = all_vers and pkg.name != profile_name
             versions = [
                 str(p.version)
-                for p in (self.find(pkg.name) if all_vers else [pkg])
+                for p in (self.find(pkg.name) if _all_vers else [pkg])
             ]
             packages[pkg.name] = {
                 "package": pkg,

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -919,6 +919,7 @@ class Controller(QtCore.QObject):
             active_profile = profile_versions[version_name]
 
             if profile_name:
+                # (TODO): this warning pops-up even profile actually exists
                 self.warning("%s was not found" % profile_name)
             else:
                 self.error("select_profile was passed an empty string")

--- a/allzpark/control.py
+++ b/allzpark/control.py
@@ -364,18 +364,26 @@ class Controller(QtCore.QObject):
 
         """
         all_vers = self._state.retrieve("showAllVersions", False)
+        app_vers = self._models["apps"].find(app_request)["versions"]
+        app_names = {app.name for app in self._state["rezApps"].values()}
         profile_name = self._state["profileName"]
         resolved = self._state["rezContexts"][app_request].resolved_packages
 
         packages = odict()  # keep resolved order
         for pkg in resolved or []:
             is_profile = pkg.name == profile_name
-            all_vers_ = all_vers and not is_profile
+            is_app = False if is_profile else pkg.name in app_names
 
-            versions = [
-                str(p.version)
-                for p in (self.find(pkg.name) if all_vers_ else [pkg])
-            ]
+            if is_profile:
+                versions = [str(pkg.version)]
+            elif is_app:
+                versions = app_vers[:]
+            else:
+                versions = [
+                    str(p.version)
+                    for p in (self.find(pkg.name) if all_vers else [pkg])
+                ]
+
             packages[pkg.name] = {
                 "package": pkg,
                 "versions": versions,

--- a/allzpark/delegates.py
+++ b/allzpark/delegates.py
@@ -53,4 +53,6 @@ class Package(QtWidgets.QStyledItemDelegate):
         if not version or version == default:
             return
 
-        self._ctrl.patch("%s==%s" % (package, version))
+        app_request = "%s==%s" % (package, version)
+        self._ctrl.state.store("startupApplication", app_request)
+        self._ctrl.patch(app_request)

--- a/allzpark/delegates.py
+++ b/allzpark/delegates.py
@@ -53,6 +53,11 @@ class Package(QtWidgets.QStyledItemDelegate):
         if not version or version == default:
             return
 
-        app_request = "%s==%s" % (package, version)
-        self._ctrl.state.store("startupApplication", app_request)
-        self._ctrl.patch(app_request)
+        patch_request = "%s==%s" % (package, version)
+
+        for app_pkg in self._ctrl.state["rezApps"].values():
+            if app_pkg.name == package:
+                self._ctrl.state.store("startupApplication", patch_request)
+                break
+
+        self._ctrl.patch(patch_request)

--- a/allzpark/delegates.py
+++ b/allzpark/delegates.py
@@ -24,7 +24,7 @@ class Package(QtWidgets.QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         model = index.model()
-        package = model.data(index, "name")
+        package = model.data(index, "family")
         options = model.data(index, "versions")
         default = model.data(index, "default")
         version = options[editor.currentIndex()]

--- a/allzpark/delegates.py
+++ b/allzpark/delegates.py
@@ -18,7 +18,8 @@ class Package(QtWidgets.QStyledItemDelegate):
         self._ctrl = ctrl
 
     def createEditor(self, parent, option, index):
-        if index.column() != 1:
+        model = index.model()
+        if index.column() != 1 or not model.data(index, "_hasVersions"):
             return
 
         editor = QtWidgets.QComboBox(parent)

--- a/allzpark/delegates.py
+++ b/allzpark/delegates.py
@@ -53,11 +53,4 @@ class Package(QtWidgets.QStyledItemDelegate):
         if not version or version == default:
             return
 
-        patch_request = "%s==%s" % (package, version)
-
-        for app_pkg in self._ctrl.state["rezApps"].values():
-            if app_pkg.name == package:
-                self._ctrl.state.store("startupApplication", patch_request)
-                break
-
-        self._ctrl.patch(patch_request)
+        self._ctrl.patch("%s==%s" % (package, version))

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -343,15 +343,15 @@ class Packages(AbstractDockWidget):
 
     def on_argument_changed(self, arg):
         if arg["name"] == "useDevelopmentPackages":
-            self._ctrl._state.store("useDevelopmentPackages", arg.read())
+            self._ctrl.state.store("useDevelopmentPackages", arg.read())
             self._ctrl.reset()
 
         if arg["name"] == "useLocalizedPackages":
-            self._ctrl._state.store("useLocalizedPackages", arg.read())
+            self._ctrl.state.store("useLocalizedPackages", arg.read())
             self._ctrl.reset()
 
         if arg["name"] == "patch":
-            self._ctrl._state.store("patch", arg.read())
+            self._ctrl.state.store("patch", arg.read())
             self._ctrl.reset()
 
     def on_resetted(self):

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -1060,96 +1060,99 @@ class Preferences(AbstractDockWidget):
 
     icon = "Action_GoHome_32"
 
-    options = [
-        qargparse.Info("startupProfile", help=(
-            "Load this profile on startup"
-        )),
-        qargparse.Info("startupApplication", help=(
-            "Load this application on startup"
-        )),
-
-        qargparse.Separator("Appearance"),
-
-        qargparse.Enum("theme", items=res.theme_names(), help=(
-            "GUI skin. May need to restart Allzpark after changed."
-        )),
-
-        qargparse.Button("resetLayout", help=(
-            "Reset stored layout to their defaults"
-        )),
-
-        qargparse.Separator("Settings"),
-
-        qargparse.Boolean("smallIcons", enabled=False, help=(
-            "Draw small icons"
-        )),
-        qargparse.Boolean("allowMultipleDocks", help=(
-            "Allow more than one dock to exist at a time"
-        )),
-        qargparse.Boolean("showAdvancedControls", help=(
-            "Show developer-centric controls"
-        )),
-        qargparse.Boolean("showAllApps", help=(
-            "List everything from allzparkconfig:applications\n"
-            "not just the ones specified for a given profile."
-        )),
-        qargparse.Boolean("showHiddenApps", help=(
-            "Show apps with metadata['hidden'] = True"
-        )),
-        qargparse.Boolean("showAllVersions", help=(
-            "Show all package versions.\n"
-            "Profile requested application version range will still be \n"
-            "respected, but all versions of each dependency package will \n"
-            "be shown."
-        )),
-        qargparse.Boolean("patchWithFilter", help=(
-            "Use the current exclusion filter when patching.\n"
-            "This enables patching of packages outside of a filter, \n"
-            "such as *.beta packages, with every other package still \n"
-            "qualifying for that filter."
-        )),
-        qargparse.Integer("clearCacheTimeout", min=1, default=10, help=(
-            "Clear package repository cache at this interval, in seconds. \n\n"
-
-            "Default 10. (Requires restart)\n\n"
-
-            "Normally, filesystem calls like `os.listdir` are cached \n"
-            "so as to avoid unnecessary calls. However, whenever a new \n"
-            "version of a package is released, it will remain invisible \n"
-            "until this cache is cleared. \n\n"
-
-            "Clearing ths cache should have a very small impact on \n"
-            "performance and is safe to do frequently. It has no effect \n"
-            "on memcached which has a much greater impact on performanc."
-        )),
-
-        qargparse.String(
-            "exclusionFilter",
-            default=allzparkconfig.exclude_filter,
-            help="Exclude versions that match this expression"),
-
-        qargparse.Separator("System"),
-
-        # Provided by controller
-        qargparse.Info("pythonExe"),
-        qargparse.Info("pythonVersion"),
-        qargparse.Info("qtVersion"),
-        qargparse.Info("qtBinding"),
-        qargparse.Info("qtBindingVersion"),
-        qargparse.Info("rezLocation"),
-        qargparse.Info("rezVersion"),
-        qargparse.Info("rezConfigFile"),
-        qargparse.Info("memcachedURI"),
-        qargparse.InfoList("rezPackagesPath"),
-        qargparse.InfoList("rezLocalPath"),
-        qargparse.InfoList("rezReleasePath"),
-        qargparse.Info("settingsPath"),
-    ]
-
     def __init__(self, window, ctrl, parent=None):
         super(Preferences, self).__init__("Preferences", parent)
         self.setAttribute(QtCore.Qt.WA_StyledBackground)
         self.setObjectName("Preferences")
+
+        self.options = [
+            qargparse.Info("startupProfile", help=(
+                "Load this profile on startup"
+            )),
+            qargparse.Info("startupApplication", help=(
+                "Load this application on startup"
+            )),
+
+            qargparse.Separator("Appearance"),
+
+            qargparse.Enum("theme", items=res.theme_names(), help=(
+                "GUI skin. May need to restart Allzpark after changed."
+            )),
+
+            qargparse.Button("resetLayout", help=(
+                "Reset stored layout to their defaults"
+            )),
+
+            qargparse.Separator("Settings"),
+
+            qargparse.Boolean("smallIcons", enabled=False, help=(
+                "Draw small icons"
+            )),
+            qargparse.Boolean("allowMultipleDocks", help=(
+                "Allow more than one dock to exist at a time"
+            )),
+            qargparse.Boolean("showAdvancedControls", help=(
+                "Show developer-centric controls"
+            )),
+            qargparse.Boolean("showAllApps", help=(
+                "List everything from allzparkconfig:applications\n"
+                "not just the ones specified for a given profile."
+            )),
+            qargparse.Boolean("showHiddenApps", help=(
+                "Show apps with metadata['hidden'] = True"
+            )),
+            qargparse.Boolean("showAllVersions", help=(
+                "Show all package versions.\n"
+                "Profile requested application version range will \n"
+                "still be respected, but all versions of each \n"
+                "dependency package will be shown."
+            )),
+            qargparse.Boolean("patchWithFilter", help=(
+                "Use the current exclusion filter when patching.\n"
+                "This enables patching of packages outside of a \n"
+                "filter, such as *.beta packages, with every other \n"
+                "package still qualifying for that filter."
+            )),
+            qargparse.Integer("clearCacheTimeout", min=1, default=10, help=(
+                "Clear package repository cache at this interval, in \n"
+                "seconds.\n\n"
+    
+                "Default 10. (Requires restart)\n\n"
+    
+                "Normally, filesystem calls like `os.listdir` are \n"
+                "cached so as to avoid unnecessary calls. However, \n"
+                "whenever a new version of a package is released, \n"
+                "it will remain invisible until this cache is \n"
+                "cleared. \n\n"
+    
+                "Clearing ths cache should have a very small impact \n"
+                "on performance and is safe to do frequently. It has \n"
+                "no effect on memcached which has a much greater \n"
+                "impact on performance."
+            )),
+
+            qargparse.String(
+                "exclusionFilter",
+                default=allzparkconfig.exclude_filter,
+                help="Exclude versions that match this expression"),
+
+            qargparse.Separator("System"),
+
+            # Provided by controller
+            qargparse.Info("pythonExe"),
+            qargparse.Info("pythonVersion"),
+            qargparse.Info("qtVersion"),
+            qargparse.Info("qtBinding"),
+            qargparse.Info("qtBindingVersion"),
+            qargparse.Info("rezLocation"),
+            qargparse.Info("rezVersion"),
+            qargparse.Info("rezConfigFile"),
+            qargparse.Info("memcachedURI"),
+            qargparse.InfoList("rezPackagesPath"),
+            qargparse.InfoList("rezLocalPath"),
+            qargparse.InfoList("rezReleasePath"),
+            qargparse.Info("settingsPath"),
+        ]
 
         protected = allzparkconfig.protected_preferences()
         for name, value in protected.items():

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -640,15 +640,16 @@ class Context(AbstractDockWidget):
         self._model = model_
 
     def on_state_appfailed(self):
-        self._widgets["generateGraph"].setEnabled(False)
         self._widgets["printCode"].setEnabled(False)
 
     def on_state_appok(self):
-        self._widgets["generateGraph"].setEnabled(True)
         self._widgets["printCode"].setEnabled(True)
 
     def on_generate_clicked(self):
         pixmap = self._ctrl.graph()
+
+        if pixmap is None:
+            return  # was graphing broken context
 
         if not pixmap:
             self._widgets["graphHotkeys"].setText(

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -1155,6 +1155,15 @@ class Preferences(AbstractDockWidget):
         self.setAttribute(QtCore.Qt.WA_StyledBackground)
         self.setObjectName("Preferences")
 
+        protected = allzparkconfig.protected_preferences()
+        for name, value in protected.items():
+            arg = next((a for a in self.options if a["name"] == name), None)
+            if arg is None:
+                print("Unknown preference setting: %s" % name)
+            else:
+                ctrl.state.store(name, value)
+                arg["enabled"] = False
+
         panels = {
             "central": QtWidgets.QTabWidget(),
         }

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -1093,7 +1093,12 @@ class Preferences(AbstractDockWidget):
         qargparse.Boolean("showHiddenApps", help=(
             "Show apps with metadata['hidden'] = True"
         )),
-
+        qargparse.Boolean("showAllVersions", help=(
+            "Show all package versions.\n"
+            "Profile requested application version range will still be \n"
+            "respected, but all versions of each dependency package will \n"
+            "be shown."
+        )),
         qargparse.Boolean("patchWithFilter", help=(
             "Use the current exclusion filter when patching.\n"
             "This enables patching of packages outside of a filter, \n"

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -465,8 +465,17 @@ class Packages(AbstractDockWidget):
             localize_all.setEnabled(False)
             localize_related.setEnabled(False)
 
+        versions = model_.data(index, "versions")
+        if len(versions) <= 1:
+            edit.setEnabled(False)
+            default.setEnabled(False)
+            earliest.setEnabled(False)
+            latest.setEnabled(False)
+
         def on_edit():
-            self._widgets["view"].edit(index)
+            # avoid sending index that is not editable
+            version_index = model_.index(index.row(), 1)
+            self._widgets["view"].edit(version_index)
 
         def on_default():
             package = model_.data(index, "package")
@@ -474,7 +483,6 @@ class Packages(AbstractDockWidget):
             self.message.emit("Package set to default")
 
         def on_earliest():
-            versions = model_.data(index, "versions")
             earliest = versions[0]
             package = model_.data(index, "package")
             self._ctrl.patch("%s==%s" % (package.name, earliest))
@@ -482,7 +490,6 @@ class Packages(AbstractDockWidget):
             self.message.emit("Package set to earliest")
 
         def on_latest():
-            versions = model_.data(index, "versions")
             latest = versions[-1]
             package = model_.data(index, "package")
             self._ctrl.patch("%s==%s" % (package.name, latest))

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -351,6 +351,9 @@ class Packages(AbstractDockWidget):
             self._ctrl.reset()
 
         if arg["name"] == "patch":
+            # (TODO) This will be called twice since qargparse.String
+            #   may emit changed signal twice. And profile model item
+            #   will get doubled.
             self._ctrl.state.store("patch", arg.read())
             self._ctrl.reset()
 

--- a/allzpark/dock.py
+++ b/allzpark/dock.py
@@ -174,7 +174,7 @@ class App(AbstractDockWidget):
             return
 
         ctrl = self._ctrl
-        model = ctrl.models["resolved"]
+        model = ctrl.models["apps"]
         app_name = ctrl.state["appRequest"]
         app_index = model.findIndex(app_name)
         value = arg.read()
@@ -364,16 +364,11 @@ class Packages(AbstractDockWidget):
         arg._previous = patch
 
     def set_model(self, model_):
-        proxy_model = model.PackagesProxyModel(model_)
-        proxy_model.setup(include=[("request", None)])
+        proxy_model = model.ProxyModel(model_)
         self._widgets["view"].setModel(proxy_model)
 
         model_.modelReset.connect(self.on_model_changed)
         model_.dataChanged.connect(self.on_model_changed)
-
-    def on_app_changed(self, app_request):
-        model_ = self._widgets["view"].model()
-        model_.setup(include=[("request", app_request)])
 
     def on_model_changed(self):
         model_ = self._widgets["view"].model()
@@ -678,7 +673,7 @@ class Context(AbstractDockWidget):
 
         self._widgets["code"].setText("<br>".join(pretty))
 
-    def on_application_changed(self, app_request):
+    def on_application_changed(self):
         self._widgets["code"].setPlainText("")
         if not self._widgets["graph"]._pixmapHandle:
             return

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -182,7 +182,9 @@ class AbstractPackageItem(dict):
 
 class ApplicationItem(AbstractPackageItem):
 
-    def __init__(self, app_request, app_pkg, versions):
+    def __init__(self, app_request, data):
+        app_pkg = data["package"]
+        versions = data["versions"]
         metadata = allzparkconfig.metadata_from_package(app_pkg)
         tools = getattr(app_pkg, "tools", None) or [app_pkg.name]
 
@@ -201,7 +203,9 @@ class ApplicationItem(AbstractPackageItem):
 
 class PackageItem(AbstractPackageItem):
 
-    def __init__(self, name, package, versions, override, disabled):
+    def __init__(self, name, data):
+        package = data["package"]
+        versions = data["versions"]
         metadata = allzparkconfig.metadata_from_package(package)
         relocatable = localz.is_relocatable(package) if localz else False
         state = (
@@ -215,8 +219,8 @@ class PackageItem(AbstractPackageItem):
                                           versions=versions,
                                           metadata=metadata)
         self.update({
-            "override": override,
-            "disabled": disabled,
+            "override": data["override"],
+            "disabled": data["disabled"],
             "state": state,
             "relocatable": relocatable,
             "localizing": False,  # in progress
@@ -250,9 +254,7 @@ class ApplicationModel(AbstractTableModel):
         self.items[:] = []
 
         for app_request, data in applications.items():
-            app = data["package"]
-            versions = data["versions"]
-            item = ApplicationItem(app_request, app, versions)
+            item = ApplicationItem(app_request, data)
             self.items.append(item)
 
         self.endResetModel()
@@ -414,12 +416,10 @@ class PackagesModel(AbstractTableModel):
         self.items[:] = []
 
         for name, data in packages.items():
-            pkg = data["package"]
-            versions = data["versions"]
-            override = self._overrides.get(pkg.name)
-            disabled = self._disabled.get(pkg.name, False)
+            data["override"] = self._overrides.get(name)
+            data["disabled"] = self._disabled.get(name, False)
 
-            item = PackageItem(name, pkg, versions, override, disabled)
+            item = PackageItem(name, data)
             self.items.append(item)
 
         self.endResetModel()

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -333,7 +333,7 @@ class ResolvedPackagesModel(AbstractTableModel):
             return "x" if re.findall(r".beta$", version) else ""
 
         if key == "latest":
-            # TODO: this is not the real latest
+            # (TODO): This is not the real latest
             version = data["override"] or data["version"]
             latest = data["versions"][-1]
             return "x" if version == latest else ""

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -79,10 +79,9 @@ class AbstractTableModel(QtCore.QAbstractTableModel):
     def find(self, name):
         return next(i for i in self.items if i["name"] == name)
 
-    def findIndex(self, name):
-        return self.createIndex(
-            self.items.index(self.find(name)), 0, QtCore.QModelIndex()
-        )
+    def findIndex(self, name, column=0):
+        row = self.items.index(self.find(name))
+        return self.createIndex(row, column, QtCore.QModelIndex())
 
     def rowCount(self, parent=QtCore.QModelIndex()):
         if parent.isValid():

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -229,6 +229,7 @@ class ResolvedPackagesModel(AbstractTableModel):
 
         item = {
             "_isApp": is_app,
+            "_hasVersions": len(versions) > 1,
 
             "name": name,
             "label": data["label"],
@@ -312,6 +313,12 @@ class ResolvedPackagesModel(AbstractTableModel):
 
             if role == QtCore.Qt.ForegroundRole:
                 return QtGui.QColor("darkorange")
+
+        if data["_hasVersions"] and col == 1:
+            if role == QtCore.Qt.FontRole:
+                font = QtGui.QFont()
+                font.setBold(True)
+                return font
 
         try:
             value = data[role]

--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -205,18 +205,18 @@ class ResolvedPackagesModel(AbstractTableModel):
 
         for app_request, app_data in packages.items():
             app = app_data["app"]
+            name = app_request
             versions = app_data["versions"]
+            self._add_item(name, app_request, app, versions, is_app=True)
 
-            self._add_item(app_request, app_request, app, versions)
-
-            for pkg in app_data["packages"]:
-                self._add_item(pkg.name, app_request, pkg)
+            for pkg, versions in app_data["packages"].items():
+                name = pkg.name
+                self._add_item(name, app_request, pkg, versions)
 
         self.endResetModel()
 
-    def _add_item(self, name, app_request, pkg, versions=None):
+    def _add_item(self, name, app_request, pkg, versions, is_app=False):
         root = pkg.root
-        is_app = versions is not None
         data = allzparkconfig.metadata_from_package(pkg)
         tools = getattr(pkg, "tools", None) or [pkg.name]
         version = str(pkg.version)
@@ -233,7 +233,7 @@ class ResolvedPackagesModel(AbstractTableModel):
             "name": name,
             "label": data["label"],
             "version": version,
-            "versions": versions or [version],
+            "versions": versions,
             "icon": parse_icon(root, template=data["icon"]),
             "package": pkg,
             "context": None,
@@ -333,7 +333,6 @@ class ResolvedPackagesModel(AbstractTableModel):
             return "x" if re.findall(r".beta$", version) else ""
 
         if key == "latest":
-            # (TODO): This is not the real latest
             version = data["override"] or data["version"]
             latest = data["versions"][-1]
             return "x" if version == latest else ""

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -699,11 +699,12 @@ class Window(QtWidgets.QMainWindow):
             for widget in self._docks.values():
                 widget.setEnabled(False)
 
-        if state in ("pkgnotfound", "errored"):
+        if state in ("pkgnotfound", "errored", "console"):
             console = self._docks["console"]
             console.show()
             self.on_dock_toggled(console, visible=True)
 
+        if state in ("pkgnotfound", "errored"):
             page = self._pages["errored"]
             self._panels["pages"].setCurrentWidget(page)
             self._widgets["apps"].setEnabled(False)

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -507,6 +507,7 @@ class Window(QtWidgets.QMainWindow):
 
         if key in ("showAllApps",
                    "showHiddenApps",
+                   "showAllVersions",
                    "patchWithFilter"):
             self._ctrl.reset()
 

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -500,9 +500,11 @@ class Window(QtWidgets.QMainWindow):
 
         if key in ("showAllApps",
                    "showHiddenApps",
-                   "showAllVersions",
                    "patchWithFilter"):
             self._ctrl.reset()
+
+        if key == "showAllVersions":
+            self._ctrl.select_application(self._ctrl.state["appRequest"])
 
         if key == "exclusionFilter":
             allzparkconfig.exclude_filter = value

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -59,13 +59,6 @@ class Applications(dock.SlimTableView):
     def is_selected_app_ok(self):
         return self._selected_app_ok
 
-    def setModel(self, model_):
-        proxy_model = model.ApplicationProxyModel(model_)
-        proxy_model.setup(include=[
-            ("_isApp", True)
-        ])
-        super(Applications, self).setModel(proxy_model)
-
 
 class Window(QtWidgets.QMainWindow):
     title = "Allzpark %s" % version
@@ -299,14 +292,15 @@ class Window(QtWidgets.QMainWindow):
 
         docks["profiles"].set_model(ctrl.models["profiles"],
                                     ctrl.models["profileVersions"])
-        docks["packages"].set_model(ctrl.models["resolved"])
+        docks["packages"].set_model(ctrl.models["packages"])
         docks["context"].set_model(ctrl.models["context"])
         docks["environment"].set_model(ctrl.models["environment"],
                                        ctrl.models["parentenv"],
                                        ctrl.models["diagnose"])
         docks["commands"].set_model(ctrl.models["commands"])
 
-        widgets["apps"].setModel(ctrl.models["resolved"])
+        proxy_model = model.ProxyModel(ctrl.models["apps"])
+        widgets["apps"].setModel(proxy_model)
 
         widgets["errorMessage"].setAlignment(QtCore.Qt.AlignHCenter)
 
@@ -329,7 +323,7 @@ class Window(QtWidgets.QMainWindow):
         selection_model = widgets["apps"].selectionModel()
         selection_model.selectionChanged.connect(self.on_app_selection_changed)
 
-        ctrl.models["resolved"].modelReset.connect(self.on_apps_reset)
+        ctrl.models["apps"].modelReset.connect(self.on_apps_reset)
         ctrl.models["profiles"].modelReset.connect(
             self.on_profilename_reset)
         ctrl.models["profileVersions"].modelReset.connect(
@@ -342,7 +336,6 @@ class Window(QtWidgets.QMainWindow):
         ctrl.repository_changed.connect(self.on_repository_changed)
         ctrl.command_changed.connect(self.on_command_changed)
         ctrl.application_changed.connect(self.on_app_changed)
-        ctrl.application_changed.connect(docks["packages"].on_app_changed)
 
         self._pages = pages
         self._widgets = widgets
@@ -739,7 +732,7 @@ class Window(QtWidgets.QMainWindow):
         app = self._ctrl.state.retrieve("startupApplication")
 
         row = 0
-        model = self._ctrl.models["resolved"]
+        model = self._ctrl.models["apps"]
 
         if app:
             for row_ in range(model.rowCount()):
@@ -782,7 +775,7 @@ class Window(QtWidgets.QMainWindow):
         app_request = model.data(index, "name")
         self._ctrl.select_application(app_request)
 
-    def on_app_changed(self, app_request):
+    def on_app_changed(self):
         selection_model = self._widgets["apps"].selectionModel()
         index = selection_model.selectedIndexes()[0]
         self._docks["app"].refresh(index)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,7 @@ jobs:
                                python3-pyside2.qtgui \
                                python3-pyside2.qtwidgets \
                                python3-pyside2.qtsvg
+          sudo pip install pyside2
           sudo python -c "from PySide2 import QtCore;print(QtCore.__version__)"
         condition: startsWith(variables['python.version'], '3.')
         displayName: "Install PySide2"

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -31,10 +31,7 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
@@ -82,10 +79,7 @@ class TestApps(util.TestBase):
                 }
             },
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")
@@ -134,10 +128,7 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -160,10 +151,7 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -193,10 +181,7 @@ class TestApps(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         context_a = self.ctrl.state["rezContexts"]["app_A==1"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -220,10 +205,7 @@ class TestApps(util.TestBase):
             "app_A": {"1": {"name": "app_A", "version": "1"}},
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         context_a = self.ctrl.state["rezContexts"]["app_A==2"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]

--- a/tests/test_docks.py
+++ b/tests/test_docks.py
@@ -6,8 +6,6 @@ class TestDocks(util.TestBase):
 
     def test_feature_blocked_on_failed_app(self):
         """Test feature blocked if application is broken"""
-        self.set_preference("showAdvancedControls", True)
-
         util.memory_repository({
             "foo": {
                 "1.0.0": {
@@ -22,6 +20,8 @@ class TestDocks(util.TestBase):
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
         self.ctrl_reset(["foo"])
+
+        self.set_preference("showAdvancedControls", True)
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -50,9 +50,6 @@ class TestDocks(util.TestBase):
         self._test_version_editable(show_all_version=False)
 
     def _test_version_editable(self, show_all_version):
-        self.set_preference("showAdvancedControls", True)
-        self.set_preference("showAllVersions", show_all_version)
-
         util.memory_repository({
             "foo": {
                 "1": {"name": "foo", "version": "1",
@@ -67,6 +64,11 @@ class TestDocks(util.TestBase):
                     "2": {"name": "bar", "version": "2"}}
         })
         self.ctrl_reset(["foo"])
+
+        self.set_preference("showAdvancedControls", True)
+        self.set_preference("showAllVersions", show_all_version)
+        self.wait(200)  # wait for reset
+
         self.select_application("app_B==1")
 
         dock = self.show_dock("packages")

--- a/tests/test_docks.py
+++ b/tests/test_docks.py
@@ -6,6 +6,8 @@ class TestDocks(util.TestBase):
 
     def test_feature_blocked_on_failed_app(self):
         """Test feature blocked if application is broken"""
+        self.set_preference("showAdvancedControls", True)
+
         util.memory_repository({
             "foo": {
                 "1.0.0": {
@@ -19,10 +21,7 @@ class TestDocks(util.TestBase):
             },
             "app_B": {"1": {"name": "app_B", "version": "1"}},
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         context_a = self.ctrl.state["rezContexts"]["app_A==None"]
         context_b = self.ctrl.state["rezContexts"]["app_B==1"]
@@ -30,11 +29,8 @@ class TestDocks(util.TestBase):
         self.assertFalse(context_a.success)
         self.assertTrue(context_b.success)
 
-        self.show_advance_controls()
-
         for app, state in {"app_A==None": False, "app_B==1": True}.items():
-            self.ctrl.select_application(app)
-            self.wait(100)
+            self.select_application(app)
 
             dock = self.show_dock("environment", on_page="diagnose")
             self.assertEqual(dock._widgets["compute"].isEnabled(), state)
@@ -44,3 +40,60 @@ class TestDocks(util.TestBase):
 
             dock = self.show_dock("app")
             self.assertEqual(dock._widgets["launchBtn"].isEnabled(), state)
+
+    def test_version_editable_on_show_all_versions(self):
+        """Test version is editable when show all version enabled"""
+        self._test_version_editable(show_all_version=True)
+
+    def test_version_editable_on_not_show_all_versions(self):
+        """Test version is not editable when show all version disabled"""
+        self._test_version_editable(show_all_version=False)
+
+    def _test_version_editable(self, show_all_version):
+        self.set_preference("showAdvancedControls", True)
+        self.set_preference("showAllVersions", show_all_version)
+
+        util.memory_repository({
+            "foo": {
+                "1": {"name": "foo", "version": "1",
+                      "requires": ["~app_A", "~app_B"]},
+                "2": {"name": "foo", "version": "2",
+                      "requires": ["~app_A", "~app_B"]},
+            },
+            "app_A": {"1": {"name": "app_A", "version": "1"}},
+            "app_B": {"1": {"name": "app_B", "version": "1",
+                            "requires": ["bar"]}},
+            "bar": {"1": {"name": "bar", "version": "1"},
+                    "2": {"name": "bar", "version": "2"}}
+        })
+        self.ctrl_reset(["foo"])
+        self.select_application("app_B==1")
+
+        dock = self.show_dock("packages")
+        view = dock._widgets["view"]
+        proxy = view.model()
+        model = proxy.sourceModel()
+
+        for pkg, state in {"foo": False,  # profile can't change version here
+                           "bar": show_all_version,
+                           "app_B": False}.items():
+            index = model.findIndex(pkg)
+            index = proxy.mapFromSource(index)
+
+            rect = view.visualRect(index)
+            position = rect.center()
+            with util.patch_cursor_pos(view.mapToGlobal(position)):
+                dock.on_right_click(position)
+                menu = self.get_menu(dock)
+                edit_action = next((a for a in menu.actions()
+                                    if a.text() == "Edit"), None)
+                if edit_action is None:
+                    self.fail("No version edit action.")
+
+                self.assertEqual(
+                    edit_action.isEnabled(), state,
+                    "Package '%s' version edit state is incorrect." % pkg
+                )
+
+                self.wait(200)
+                menu.close()

--- a/tests/test_docks.py
+++ b/tests/test_docks.py
@@ -39,9 +39,6 @@ class TestDocks(util.TestBase):
             dock = self.show_dock("environment", on_page="diagnose")
             self.assertEqual(dock._widgets["compute"].isEnabled(), state)
 
-            dock = self.show_dock("context", on_page="graph")
-            self.assertEqual(dock._widgets["generateGraph"].isEnabled(), state)
-
             dock = self.show_dock("context", on_page="code")
             self.assertEqual(dock._widgets["printCode"].isEnabled(), state)
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -22,10 +22,7 @@ class TestLaunch(util.TestBase):
                 }
             },
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -93,10 +93,7 @@ class TestProfiles(util.TestBase):
                 }
             },
         })
-        with self.wait_signal(self.ctrl.resetted):
-            self.ctrl.reset(["foo"])
-        self.wait(timeout=200)
-        self.assertEqual(self.ctrl.state.state, "ready")
+        self.ctrl_reset(["foo"])
 
         with self.wait_signal(self.ctrl.state_changed, "ready"):
             self.ctrl.select_profile("foo")

--- a/tests/util.py
+++ b/tests/util.py
@@ -45,6 +45,8 @@ class TestBase(unittest.TestCase):
     def tearDown(self):
         self.wait(timeout=500)
         self.window.close()
+        self.ctrl.deleteLater()
+        self.window.deleteLater()
         time.sleep(0.1)
 
     def set_preference(self, name, value):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,5 @@
 
 import os
-import time
 import unittest
 import contextlib
 
@@ -43,45 +42,20 @@ class TestBase(unittest.TestCase):
         self.wait(timeout=50)
 
     def tearDown(self):
-        self.wait(timeout=500)
+        self.wait(timeout=200)
         self.window.close()
-        time.sleep(0.1)
 
     def set_preference(self, name, value):
-        """Setup preference
-
-        This should be called before ctrl reset.
-
-        (NOTE) Some preference change may calling ctrl.reset, so ctrl.reset
-            will be monkey-patched to do nothing, this is to prevent error
-            raised from resting without profile.
-            If not doing this, and setup preference after reset with test
-            profiles, calling reset again on preference changed may leads
-            to some weird profile model reset error. (item.internalPointer
-            returning random object and AttributeError raised)
-
-        Args:
-            name: preference name
-            value: preference value
-
-        Returns:
-            None
-
-        """
         preferences = self.window._docks["preferences"]
         arg = next((opt for opt in preferences.options
                     if opt["name"] == name), None)
         if not arg:
             self.fail("Preference doesn't have this setting: %s" % name)
 
-        origin_reset = getattr(self.ctrl, "reset")
-        setattr(self.ctrl, "reset", lambda: None)
         try:
             arg.write(value)
         except Exception as e:
             self.fail("Preference '%s' set failed: %s" % (name, str(e)))
-        finally:
-            setattr(self.ctrl, "reset", origin_reset)
 
     def show_dock(self, name, on_page=None):
         dock = self.window._docks[name]

--- a/tests/util.py
+++ b/tests/util.py
@@ -39,6 +39,7 @@ class TestBase(unittest.TestCase):
         self.app = app
         self.ctrl = ctrl
         self.window = window
+        self.patched_allzparkconfig = dict()
 
         self.wait(timeout=50)
 
@@ -47,7 +48,25 @@ class TestBase(unittest.TestCase):
         self.window.close()
         self.ctrl.deleteLater()
         self.window.deleteLater()
+        self._restore_allzparkconfig()
         time.sleep(0.1)
+
+    def _restore_allzparkconfig(self):
+        from allzpark import allzparkconfig
+
+        for name, value in self.patched_allzparkconfig.items():
+            setattr(allzparkconfig, name, value)
+
+        self.patched_allzparkconfig.clear()
+
+    def patch_allzparkconfig(self, name, value):
+        from allzpark import allzparkconfig
+
+        if name not in self.patched_allzparkconfig:
+            original = getattr(allzparkconfig, name)
+            self.patched_allzparkconfig[name] = original
+
+        setattr(allzparkconfig, name, value)
 
     def set_preference(self, name, value):
         preferences = self.window._docks["preferences"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,6 @@
 
 import os
+import time
 import unittest
 import contextlib
 
@@ -42,8 +43,9 @@ class TestBase(unittest.TestCase):
         self.wait(timeout=50)
 
     def tearDown(self):
-        self.wait(timeout=200)
+        self.wait(timeout=500)
         self.window.close()
+        time.sleep(0.1)
 
     def set_preference(self, name, value):
         preferences = self.window._docks["preferences"]


### PR DESCRIPTION
### What's Changed

* Application package version can be changed in main view (#96)
* Version list has been limited to profile request range (#127)

### Internal Refactor

* ~`PackagesModel` and `ApplicationModel` has been merged into one `ResolvedPackagesModel`.~
* ~Two proxy model were added to adopt the above merge : `ApplicationProxyModel` and `PackagesProxyModel`.~
* Controller is no longer required for resetting package model.

### Discussion

After package version list has been limited to only show in the range that profile requested, the `latest` flag is not reflecting *real* latest anymore.

But do we need to know whether a package is latest or not ? I do imaging that sometime we indeed want to know that info, but should not be often. So I would propose to implement that query action in a menu, and only scan all versions when one needed.

Secondly, do we still need the "Set to earliest" and "Set to latest" action ?
<details><summary> action snapshot </summary>

![image](https://user-images.githubusercontent.com/3357009/98837870-74439f00-247e-11eb-85b1-8c3f37482bbd.png)

</details>

I am more lean to respect the request what profile have made, and not allowing change denpency version freely.

What do you think ?

