### PR TITLE
Ensure path case normalized

### DIFF
--- a/allzpark/model.py
+++ b/allzpark/model.py
@@ -303,12 +303,10 @@ def is_local(pkg):
         return False
 
     local_path = rez.config.local_packages_path
-    local_path = os.path.abspath(local_path)
-    local_path = os.path.normpath(local_path)
+    local_path = util.normpath(local_path)
 
     pkg_path = pkg.resource.location
-    pkg_path = os.path.abspath(pkg_path)
-    pkg_path = os.path.normpath(pkg_path)
+    pkg_path = util.normpath(pkg_path)
 
     return pkg_path.startswith(local_path)
 

--- a/allzpark/util.py
+++ b/allzpark/util.py
@@ -191,7 +191,7 @@ def open_file_location(fname):
 
 def normpath(path):
     return os.path.normpath(
-        os.path.abspath(path).replace("\\", "/")
+        os.path.normcase(os.path.abspath(path)).replace("\\", "/")
     )
 
 


### PR DESCRIPTION
### Problem

Since Windows's filesystem is case-insensitive, `c:/users/david/packages` and `C:/Users/david/packages` both point to same location, but using direct string compare to find out whether these two path is the same or relatived won't work.

And that makes Allzpark fail to identify which package is local (dev) and which is localized, when registered Rez package path and package localize path is not using same letter case.

### Fix

Introduce [`os.path.normcase`](https://docs.python.org/3.7/library/os.path.html#os.path.normcase) solved the problem.
