### PR TITLE
Environment plugin

### DIFF
--- a/allzpark/allzparkconfig.py
+++ b/allzpark/allzparkconfig.py
@@ -126,6 +126,27 @@ def protected_preferences():
     return dict()
 
 
+def environment_plugin():
+    """Custom widget for adding extra environment variables
+
+    In some scenario, e.g. production pipeline involved workflow, may
+    require passing additional arguments as environment variables to
+    application that is being launched. And those environment variables,
+    like shot numbers, may change regularly so can't be fixed in Rez
+    package.
+
+    To adopt that, one could subclass `allzpark.plugin.EnvPluginBase`
+    to implement a custom widget that can be hooked with Allzpark, as
+    an additional interface for user to make production decisions, and
+    parse those inputs into application's launching environment.
+
+    Returns:
+        None or subclass of `allzpark.plugin.EnvPluginBase`
+
+    """
+    return None
+
+
 def themes():
     """Allzpark GUI theme list provider
 

--- a/allzpark/cli.py
+++ b/allzpark/cli.py
@@ -293,7 +293,7 @@ def initialize(config_file=None,
 
 
 def launch(ctrl):
-    from . import view, resources, util
+    from . import view, dock, resources, util
 
     # Handle stdio from within the application if necessary
     if hasattr(allzparkconfig, "__noconsole__"):
@@ -318,7 +318,16 @@ def launch(ctrl):
     with timings("- Loading themes.. "):
         resources.load_themes()
 
-    window = view.Window(ctrl)
+    with timings("- Loading environment plugin.. ") as msg:
+        plugin_cls = allzparkconfig.environment_plugin()
+        if plugin_cls is None:
+            plugin = None
+            msg["success"] = "no plugin - ok\n"
+        else:
+            plugin = dock.EnvironmentPlugin(ctrl, plugin_cls)
+            msg["success"] = "%s loaded - ok {:.2f}\n" % plugin.name
+
+    window = view.Window(ctrl, plugin)
     user_css = ctrl.state.retrieve("userCss", "")
     originalcss = resources.load_theme(ctrl.state.retrieve("theme"))
     # Store for CSS Editor

--- a/allzpark/cli.py
+++ b/allzpark/cli.py
@@ -243,10 +243,10 @@ def initialize(config_file=None,
                              "start anew")
 
         if clean:
-            tell("(clean) ")
+            tell("(clean) ", newlines=0)
             storage.clear()
         else:
-            tell("(%s)" % storage.fileName())
+            tell("(%s) " % storage.fileName(), newlines=0)
 
         defaults = {
             "memcachedURI": os.getenv("REZ_MEMCACHED_URI", "None"),

--- a/allzpark/plugin.py
+++ b/allzpark/plugin.py
@@ -1,0 +1,129 @@
+
+import logging
+from .vendor.Qt import QtCore, QtWidgets
+
+
+class EnvPluginBase(QtWidgets.QWidget):
+    """Base class of environment plugin"""
+
+    name = "Environment Plugin"
+
+    envChanged = QtCore.Signal(dict)
+    envReset = QtCore.Signal()
+    revealed = QtCore.Signal()
+    consoleShown = QtCore.Signal()
+    logged = QtCore.Signal(str, int)  # message, level
+
+    def on_profile_changed(self, package):
+        """Runs on profile changed
+
+        This will be called by Allzpark when profile has changed.
+        Reimplement this function if you need plugin to take actions on
+        profile change.
+
+        Args:
+            package: profile package
+
+        """
+        pass
+
+    def on_application_changed(self, package):
+        """Runs on application selection changed
+
+        This will be called by Allzpark when selected application changed.
+        Reimplement this function if you need plugin to take actions on
+        application change.
+
+        Args:
+            package: application package
+
+        """
+        pass
+
+    def validate(self, environ, package):
+        """Validate environment before launching application
+
+        This will be called by Allzpark when application is about to launch,
+        and abort launching if validation failed with message returned.
+
+        Return None if validation passed, or string message as reason why it
+        fails. Returning any value that is not equivalent to False (e.g. None,
+        "", 0) will be considered as fail and the value will be used to format
+        string error message.
+
+        Args:
+            environ (dict): env vars that merged from parent, plugin and user
+            package: application package that being launched
+
+        Returns:
+            None or str
+
+        """
+        pass
+
+    def set_env(self, env):
+        """Inject additional environment variables
+
+        The `env` will be applied on top of parent environment, and user
+        environment variables on top of it.
+
+        Multi-path variable will simply be overwritten, no appending nor
+        prepending.
+
+        Args:
+            env (dict): key-value paired environment variables
+
+        Returns:
+            None
+
+        """
+        self.envChanged.emit(env)
+
+    def clear_env(self):
+        """Reset additional environment variables
+
+        Returns:
+            None
+
+        """
+        self.envReset.emit()
+
+    def reveal(self):
+        """Activate plugin dock widget
+
+        Show plugin dock widget. Could be used when input is required and
+        need to have focus on the plugin page.
+
+        Returns:
+            None
+
+        """
+        self.revealed.emit()
+
+    def to_console(self):
+        """Activate Allzpark console dock widget
+
+        Show Allzpark console dock widget. Could be used when there are log
+        messages that need user to know.
+
+        Returns:
+            None
+
+        """
+        self.consoleShown.emit()
+
+    def debug(self, message):
+        """Send debug message to Allzpark console"""
+        self.logged.emit(message, logging.DEBUG)
+
+    def info(self, message):
+        """Send regular message to Allzpark console"""
+        self.logged.emit(message, logging.INFO)
+
+    def warning(self, message):
+        """Send warning message to Allzpark console"""
+        self.logged.emit(message, logging.WARNING)
+
+    def error(self, message):
+        """Send error message to Allzpark console"""
+        self.logged.emit(str(message), logging.ERROR)

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -547,8 +547,8 @@ class Window(QtWidgets.QMainWindow):
         if ctrl_held or not allow_multiple:
             ignore_allow_multiple = [
                 # docks that are not restricted by this rule
-                self._docks["profiles"],
-                self._docks["plugin"],
+                self._docks[name] for name in ["profiles", "plugin"]
+                if name in self._docks
             ]
             all_docks = self._docks.values()
 

--- a/allzpark/view.py
+++ b/allzpark/view.py
@@ -63,7 +63,7 @@ class Applications(dock.SlimTableView):
 class Window(QtWidgets.QMainWindow):
     title = "Allzpark %s" % version
 
-    def __init__(self, ctrl, parent=None):
+    def __init__(self, ctrl, plugin=None, parent=None):
         super(Window, self).__init__(parent)
         self.setWindowTitle(self.title)
         self.setAttribute(QtCore.Qt.WA_StyledBackground)
@@ -129,6 +129,9 @@ class Window(QtWidgets.QMainWindow):
             ("commands", dock.Commands()),
             ("preferences", dock.Preferences(self, ctrl)),
         ))
+        if plugin is not None:
+            docks["plugin"] = plugin
+            docks["environment"].enable_plugin()
 
         # Expose to CSS
         for name, widget in chain(panels.items(),
@@ -226,8 +229,10 @@ class Window(QtWidgets.QMainWindow):
 
         for name, widget in docks.items():
             has_menu = hasattr(widget, "on_context_menu")
-            BtnCls = (dock.PushButtonWithMenu
-                      if has_menu else QtWidgets.QPushButton)
+            BtnCls = (dock.PushButtonWithMenu if has_menu
+                      else QtWidgets.QPushButton)
+            btn_icon = (widget.icon if isinstance(widget.icon, QtGui.QIcon)
+                        else res.icon(widget.icon))
             toggle = BtnCls()
             toggle.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                                  QtWidgets.QSizePolicy.Expanding)
@@ -235,7 +240,7 @@ class Window(QtWidgets.QMainWindow):
             toggle.setCheckable(True)
             toggle.setFlat(True)
             toggle.setProperty("type", "toggle")
-            toggle.setIcon(res.icon(widget.icon))
+            toggle.setIcon(btn_icon)
             toggle.setIconSize(QtCore.QSize(px(32), px(32)))
             toggle.setToolTip("\n".join([
                 type(widget).__name__, widget.__doc__ or ""]))
@@ -267,7 +272,7 @@ class Window(QtWidgets.QMainWindow):
             # Forward any messages
             widget.message.connect(self.tell)
 
-            _section = "left" if name == "profiles" else "dock"
+            _section = "left" if name in ["profiles", "plugin"] else "dock"
             _layouts[_section].addWidget(toggle)
 
         layout = QtWidgets.QVBoxLayout(panels["body"])
@@ -296,6 +301,7 @@ class Window(QtWidgets.QMainWindow):
         docks["context"].set_model(ctrl.models["context"])
         docks["environment"].set_model(ctrl.models["environment"],
                                        ctrl.models["parentenv"],
+                                       ctrl.models["plugin"],
                                        ctrl.models["diagnose"])
         docks["commands"].set_model(ctrl.models["commands"])
 
@@ -313,6 +319,13 @@ class Window(QtWidgets.QMainWindow):
         docks["profiles"].version_changed.connect(
             self.on_profileversion_changed)
         docks["profiles"].reset.connect(self.reset)
+
+        if "plugin" in docks:
+            def on_reveal_plugin():
+                docks["plugin"].show()
+                self.on_dock_toggled(docks["plugin"], visible=True)
+            docks["plugin"].connect_plugin()
+            docks["plugin"].revealed.connect(on_reveal_plugin)
 
         widgets["reset"].clicked.connect(self.on_reset_clicked)
         widgets["continue"].clicked.connect(self.on_continue_clicked)
@@ -404,14 +417,18 @@ class Window(QtWidgets.QMainWindow):
         profile = docks[0]
         self.addDockWidget(area, profile)
 
+        if "plugin" in self._docks:
+            plugin = docks[-1]
+            self.addDockWidget(area, plugin)
+            right_docks = docks[1:-1]
+        else:
+            right_docks = docks[1:]
+
         area = QtCore.Qt.RightDockWidgetArea
-        first = docks[1]
+        first = right_docks[0]
         self.addDockWidget(area, first)
 
-        for widget in docks[2:]:
-            if widget is first:
-                continue
-
+        for widget in right_docks[1:]:
             self.addDockWidget(area, widget)
             self.tabifyDockWidget(first, widget)
 
@@ -530,15 +547,20 @@ class Window(QtWidgets.QMainWindow):
         if ctrl_held or not allow_multiple:
             ignore_allow_multiple = [
                 # docks that are not restricted by this rule
-                "profiles",
+                self._docks["profiles"],
+                self._docks["plugin"],
             ]
+            all_docks = self._docks.values()
 
-            for name, d in self._docks.items():
-                if name in ignore_allow_multiple:
-                    continue
-                d.setVisible(d == dock)
+            if dock in ignore_allow_multiple:
+                dock.setVisible(True)
+            else:
+                for d in all_docks:
+                    if d in ignore_allow_multiple:
+                        continue
+                    d.setVisible(d == dock)
 
-            if len([d for d in self._docks.values() if d.isVisible()]) <= 1:
+            if len([d for d in all_docks if d.isVisible()]) <= 1:
                 # Only one or no visible dock
                 return
 
@@ -704,6 +726,9 @@ class Window(QtWidgets.QMainWindow):
             self._panels["pages"].setCurrentWidget(page)
             self._widgets["apps"].setEnabled(False)
             self._docks["app"].on_state_appfailed()
+
+        if state == "console":
+            self._widgets["apps"].setEnabled(True)
 
         if state == "notresolved":
             pass


### PR DESCRIPTION
So this is the implementation of #113.
And seems related to #63 ?

Anyway, here we go 🚀 

### What is *environment plugin* for ?

A way that allows to build additional interface that can be embedded into Allzpark for user to make additional choices, and parse those decisions into environment variables into the application that is being launched.

For example, in production pipeline involved workflow, may require passing additional arguments as environment variables to application that is being launched. And those environment variables, like shot numbers, may change regularly so can't be easily fixed or defined in any Rez package.

The injected environment variables will be merged on top of *parent environment*, and *user environment* will be on top of them, like 👇🏼 

```python
user_env = {"foo": "bar"}
plugin_env = {"shot": "sh0100"}
parent_env = {"WINDIR": "C:\Windows", "USERNAME": "david", "PATH": "some/important;path"}
# merge
environ = parent_env.copy()
environ = dict(environ, **plugin_env)
environ = dict(environ, **user_env)
# launch application
context.execute_shell(parent_environ=environ)
```

### How to make an environment plugin ?

By subclassing `allzpark.plugin.EnvPluginBase`, here is an example I made for Avalon 👉🏼 [allzparkplugin.py](https://github.com/getblessing/rez-avalon/blob/master/python/allzparkplugin.py)

And register that subclass with `allzparkconfig.environment_plugin`

```python
# allzparkconfig.py
def environment_plugin():
    import allzparkplugin
    return allzparkplugin.AvalonLauncher
```

<details><summary>The screen shot</summary>

![image](https://user-images.githubusercontent.com/3357009/99544643-81690c80-29ef-11eb-89ad-b06ce486a44a.png)

</details>

### How does an environment plugin interact with Allzpark and vice versa ?

#### `EnvPluginBase.on_profile_changed`
A slot that will be connected with Allzpark's profile changed signal, profile package object will be sent.
This does nothing by default, you need to re-implement this.

#### `EnvPluginBase.on_application_changed`
A slot that will be connected with Allzpark's application changed signal, application package object will be sent.
This does nothing by default, you need to re-implement this.

#### `EnvPluginBase.validate`
This will be called by Allzpark when an application is about to launch, the merged environment dict (not resolved environment) will be sent with the application package that is being launched.

This provide a chance to validate whether the environment is valid or not, and stop launching process if invalid.
And of course, this does nothing by default, you need to re-implement this.

#### `EnvPluginBase.set_env`
Inject additional environment variables.

#### `EnvPluginBase.clear_env`
Reset additional environment variables.

#### `EnvPluginBase.reveal`
Call this to show plugin dock widget. Could be used when input is required and need user to focus on the plugin page.

#### `EnvPluginBase.to_console`
Call this to show Allzpark console dock widget. Could be used when there are something happened and need user to know, if the plugin widget doesn't implement any notification function.

#### `EnvPluginBase.debug`, `info`, `warning`, `error`
Send message into Allzpark console (only send message, not showing console)

---

And there it is, please let me know what you think :)
