### PR TITLE
link update for tik manager mentioning on docs

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -105,7 +105,7 @@ In Allzpark, the profile dictates what applications are available to the user, i
     - [Piper](http://www.piperpipeline.com)
     - [Mango Pipeline](https://www.mangopipeline.com/)
     - [AnimationDNA](https://github.com/kiryha/AnimationDNA)
-    - [Tik Manager](http://www.ardakutlu.com/tik-manager/)
+    - [Tik Manager4](https://github.com/masqu3rad3/tik_manager4)
 
 An application typically consists of these components.
 


### PR DESCRIPTION
Link update for Tik Manager mentioning on docs. Now it points for the new version. Old links doesn't exists anymore.

Huge thanks for the mention by the way!